### PR TITLE
Add argument/env var to set the session expiry for the AWS credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Okta AWS Account Federation integration app ID | OKTA_AWS_ACCOUNT_FEDERATION_APP_ID | `--aws-acct-fed-app-id [value]` | See [AWS Account Federation integration app](#aws-account-federation-integration-app) |
 | AWS IAM Identity Provider ARN | AWS_IAM_IDP | `--aws-iam-idp [value]` | The preferred IAM Identity Provider |
 | AWS IAM Role ARN to assume | AWS_IAM_ROLE | `--aws-iam-role [value]` | The preferred IAM role for the given IAM Identity Provider |
+| AWS Session Duration | AWS_SESSION_DURATION | `--session-duration [value]` | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. |
 | Output format | FORMAT | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file |
 | Profile | PROFILE | `--profile [value]` | Default is `default`  |
 | Display QR Code | QR_CODE | `--qr-code` | `yes` if flag is present  |

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -132,9 +132,9 @@ func buildRootCommand() *cobra.Command {
 		Short:   "okta-aws-cli - Okta federated identity for AWS CLI",
 		Long: `okta-aws-cli - Okta federated identity for AWS CLI
  
- Okta authentication for federated identity providers in support of AWS CLI.
- okta-aws-cli handles authentication to the IdP and token exchange with AWS STS 
- to collect a proper IAM role for the AWS CLI operator.`,
+Okta authentication for federated identity providers in support of AWS CLI.
+okta-aws-cli handles authentication to the IdP and token exchange with AWS STS 
+to collect a proper IAM role for the AWS CLI operator.`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := sessiontoken.NewSessionToken()
@@ -187,29 +187,29 @@ func Execute() {
 
 func resourceUsageTemplate() string {
 	return fmt.Sprintf(`%s:{{if .Runnable}}
-	 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-	 {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
- 
- %s
-	 {{.NameAndAliases}}{{end}}{{if .HasExample}}
- 
- %s
- {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
-	 
- %s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-	 {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-	 
- %s
- {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
-	 
- %s
- {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-	 
- %s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-	 {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-	 
- Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
- `,
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+%s
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+%s
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  
+%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  
+%s
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+  
+%s
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+  
+%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`,
 		ansi.Faint("Usage:"),
 		ansi.Faint("Aliases:"),
 		ansi.Faint("Examples:"),

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -88,6 +88,13 @@ func init() {
 			envVar: "AWS_IAM_ROLE",
 		},
 		{
+			name:   "session-duration",
+			short:  "s",
+			value:  "3600",
+			usage:  "Session duration for role.",
+			envVar: "AWS_SESSION_DURATION",
+		},
+		{
 			name:   "profile",
 			short:  "p",
 			value:  "default",
@@ -124,10 +131,10 @@ func buildRootCommand() *cobra.Command {
 		Use:     "okta-aws-cli",
 		Short:   "okta-aws-cli - Okta federated identity for AWS CLI",
 		Long: `okta-aws-cli - Okta federated identity for AWS CLI
-
-Okta authentication for federated identity providers in support of AWS CLI.
-okta-aws-cli handles authentication to the IdP and token exchange with AWS STS 
-to collect a proper IAM role for the AWS CLI operator.`,
+ 
+ Okta authentication for federated identity providers in support of AWS CLI.
+ okta-aws-cli handles authentication to the IdP and token exchange with AWS STS 
+ to collect a proper IAM role for the AWS CLI operator.`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			st, err := sessiontoken.NewSessionToken()
@@ -180,29 +187,29 @@ func Execute() {
 
 func resourceUsageTemplate() string {
 	return fmt.Sprintf(`%s:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-%s
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-%s
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
-  
-%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-  
-%s
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
-  
-%s
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-  
-%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-  
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`,
+	 {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+	 {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+ 
+ %s
+	 {{.NameAndAliases}}{{end}}{{if .HasExample}}
+ 
+ %s
+ {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+	 
+ %s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+	 {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+	 
+ %s
+ {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+	 
+ %s
+ {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+	 
+ %s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+	 {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+	 
+ Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+ `,
 		ansi.Faint("Usage:"),
 		ansi.Faint("Aliases:"),
 		ansi.Faint("Examples:"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,16 +30,17 @@ var Version = "0.0.3"
 
 // Config A config object for the CLI
 type Config struct {
-	OrgDomain      string
-	OIDCAppID      string
-	FedAppID       string
-	AWSIAMIdP      string
-	AWSIAMRole     string
-	Format         string
-	Profile        string
-	QRCode         bool
-	AWSCredentials string
-	HTTPClient     *http.Client
+	OrgDomain          string
+	OIDCAppID          string
+	FedAppID           string
+	AWSIAMIdP          string
+	AWSIAMRole         string
+	AWSSessionDuration int64
+	Format             string
+	Profile            string
+	QRCode             bool
+	AWSCredentials     string
+	HTTPClient         *http.Client
 }
 
 // NewConfig Creates a new config gathering values in this order of precedence:
@@ -48,15 +49,16 @@ type Config struct {
 //  3. .env file
 func NewConfig() *Config {
 	cfg := Config{
-		OrgDomain:      viper.GetString("org-domain"),
-		OIDCAppID:      viper.GetString("oidc-client-id"),
-		FedAppID:       viper.GetString("aws-acct-fed-app-id"),
-		AWSIAMIdP:      viper.GetString("aws-iam-idp"),
-		AWSIAMRole:     viper.GetString("aws-iam-role"),
-		Format:         viper.GetString("format"),
-		Profile:        viper.GetString("profile"),
-		QRCode:         viper.GetBool("qr-code"),
-		AWSCredentials: viper.GetString("aws-credentials"),
+		OrgDomain:          viper.GetString("org-domain"),
+		OIDCAppID:          viper.GetString("oidc-client-id"),
+		FedAppID:           viper.GetString("aws-acct-fed-app-id"),
+		AWSIAMIdP:          viper.GetString("aws-iam-idp"),
+		AWSIAMRole:         viper.GetString("aws-iam-role"),
+		AWSSessionDuration: viper.GetInt64("session-duration"),
+		Format:             viper.GetString("format"),
+		Profile:            viper.GetString("profile"),
+		QRCode:             viper.GetBool("qr-code"),
+		AWSCredentials:     viper.GetString("aws-credentials"),
 	}
 	if cfg.Format == "" {
 		cfg.Format = "env-var"
@@ -81,6 +83,9 @@ func NewConfig() *Config {
 	}
 	if cfg.AWSIAMRole == "" {
 		cfg.AWSIAMRole = viper.GetString("aws_iam_role")
+	}
+	if cfg.AWSSessionDuration == 0 {
+		cfg.AWSSessionDuration = viper.GetInt64("session_duration")
 	}
 	if !cfg.QRCode {
 		cfg.QRCode = viper.GetBool("qr_code")
@@ -109,6 +114,9 @@ func (c *Config) CheckConfig() error {
 	}
 	if c.FedAppID == "" {
 		errors = append(errors, "  AWS Account Federation App ID value is not set")
+	}
+	if c.AWSSessionDuration < 60 || c.AWSSessionDuration > 43200 {
+		errors = append(errors, "  AWS Session Duration must be between 60 and 43200")
 	}
 	if len(errors) > 0 {
 		return fmt.Errorf("%s", strings.Join(errors, "\n"))

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -409,10 +409,10 @@ func (s *SessionToken) promptAuthentication(da *deviceAuthorization) {
 	}
 
 	prompt := `Open the following URL to begin Okta device authorization for the AWS CLI.
- 
- %s%s
- 
- `
+
+%s%s
+
+`
 
 	fmt.Fprintf(os.Stderr, prompt, qrCode, da.VerificationURIComplete)
 }

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -199,7 +199,7 @@ func (s *SessionToken) fetchAWSCredentialWithSAMLRole(iar *idpAndRole, assertion
 	}
 	svc := sts.New(sess)
 	input := &sts.AssumeRoleWithSAMLInput{
-		DurationSeconds: aws.Int64(3600),
+		DurationSeconds: aws.Int64(s.config.AWSSessionDuration),
 		PrincipalArn:    aws.String(iar.idp),
 		RoleArn:         aws.String(iar.role),
 		SAMLAssertion:   aws.String(assertion),
@@ -409,10 +409,10 @@ func (s *SessionToken) promptAuthentication(da *deviceAuthorization) {
 	}
 
 	prompt := `Open the following URL to begin Okta device authorization for the AWS CLI.
-
-%s%s
-
-`
+ 
+ %s%s
+ 
+ `
 
 	fmt.Fprintf(os.Stderr, prompt, qrCode, da.VerificationURIComplete)
 }


### PR DESCRIPTION
This change allows the user to set the expiration time for the AWS credentials retrieved by `okta-aws-cli`. 