### PR TITLE
Clean up smalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ URL below. Then follow the directions in that wizard.
 
 ## Configuration
 
+**Note**: If your AWS IAM IdP is in a non-commerical region, such as GovCloud,
+the environmental variable
+[`AWS_REGION`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
+should be set
+[accordingly](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region).
+
 At a minimum the Okta AWS CLI requires three configuration values. These are the
 values for the [Okta Org
 domain](https://developer.okta.com/docs/guides/find-your-domain/main/), the

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Okta Org Domain | OKTA_ORG_DOMAIN | `--org-domain [value]` | Full domain hostname of the Okta org e.g. `test.okta.com` |
 | OIDC Client ID | OKTA_OIDC_CLIENT_ID | `--oidc-client-id [value]` | See [Allowed Web SSO Client](#allowed-web-sso-client) |
 | Okta AWS Account Federation integration app ID | OKTA_AWS_ACCOUNT_FEDERATION_APP_ID | `--aws-acct-fed-app-id [value]` | See [AWS Account Federation integration app](#aws-account-federation-integration-app) |
-| AWS IAM Identity Provider ARN | AWS_IAM_IDP | `--aws-iam-idp [value]` | The preferred IAM Identity Provider |
-| AWS IAM Role ARN to assume | AWS_IAM_ROLE | `--aws-iam-role [value]` | The preferred IAM role for the given IAM Identity Provider |
+| Preset the AWS IAM Identity Provider ARN | AWS_IAM_IDP | `--aws-iam-idp [value]` | Presets the IdP list to this preferred IAM Identity Provider |
+| Preset the AWS IAM Role ARN to assume | AWS_IAM_ROLE | `--aws-iam-role [value]` | Presets the role list to this preferred IAM role for the given IAM Identity Provider |
 | AWS Session Duration | AWS_SESSION_DURATION | `--session-duration [value]` | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. |
 | Output format | FORMAT | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file |
 | Profile | PROFILE | `--profile [value]` | Default is `default`  |

--- a/README.md
+++ b/README.md
@@ -285,10 +285,10 @@ Run source code locally
 go run cmd/okta-aws-cli/main.go
 ```
 
-Make file help
+Install tools that the Makefile uses like `gofumpt` and `golint`
 
 ```
-make help
+make tools
 ```
 
 Building

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -77,14 +77,14 @@ func init() {
 			name:   "aws-iam-idp",
 			short:  "i",
 			value:  "",
-			usage:  "IAM Identity Provider ARN",
+			usage:  "Preset IAM Identity Provider ARN",
 			envVar: "AWS_IAM_IDP",
 		},
 		{
 			name:   "aws-iam-role",
 			short:  "r",
 			value:  "",
-			usage:  "IAM Role ARN",
+			usage:  "Preset IAM Role ARN",
 			envVar: "AWS_IAM_ROLE",
 		},
 		{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,13 @@ func NewConfig() *Config {
 		cfg.QRCode = viper.GetBool("qr_code")
 	}
 
+	// There is always a default aws credentials path set in root.go's init
+	// function so overwrite the config value if the operator is attempting to
+	// set it by ENV VAR value.
+	if viper.GetString("aws_credentials") != "" {
+		cfg.AWSCredentials = viper.GetString("aws_credentials")
+	}
+
 	tr := &http.Transport{
 		IdleConnTimeout: 30 * time.Second,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,12 @@ func NewConfig() *Config {
 	if !cfg.QRCode {
 		cfg.QRCode = viper.GetBool("qr_code")
 	}
+	// correct org domain if it's in admin form
+	orgDomain := strings.Replace(cfg.OrgDomain, "-admin", "", -1)
+	if orgDomain != cfg.OrgDomain {
+		fmt.Printf("Warning: proactively correcting org domain %q to non-admin form %q.\n\n", cfg.OrgDomain, orgDomain)
+		cfg.OrgDomain = orgDomain
+	}
 
 	// There is always a default aws credentials path set in root.go's init
 	// function so overwrite the config value if the operator is attempting to

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -35,7 +35,7 @@ func NewAWSCredentialsFile() *AWSCredentialsFile {
 // Output Satisfies the Outputter interface and appends AWS credentials to
 // credentials file.
 func (e *AWSCredentialsFile) Output(c *config.Config, ac *aws.Credential) error {
-	f, err := os.OpenFile(c.AWSCredentials, os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(c.AWSCredentials, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/output/envvar.go
+++ b/internal/output/envvar.go
@@ -34,7 +34,6 @@ func NewEnvVar() *EnvVar {
 // Output Satisfies the Outputter interface and outputs AWS credentials as shell
 // export statements to STDOUT
 func (e *EnvVar) Output(c *config.Config, ac *aws.Credential) error {
-	fmt.Printf("export AWS_PROFILE=%s\n", c.Profile)
 	fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", ac.AccessKeyID)
 	fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", ac.SecretAccessKey)
 	fmt.Printf("export AWS_SESSION_TOKEN=%s\n", ac.SessionToken)


### PR DESCRIPTION
* Document need for `AWS_REGION` env variable if AWS IdP is in a non-commercial AWS region.
* If configured with an org domain in admin form, warn and proactively update the value.
* Correctly write creds file when `AWS_CREDENTIALS` is set.
* Document `aws-iam-idp` and `aws-iam-role` are intended as preset to the idp and roles list presented to the user.
* `AWS_PROFILE` is unnecessary in env var output.
* Illustrate `make tools` is used to install the tools the Makefile makes use of.