### PR TITLE
`--write-aws-credentials` implies format `aws-credentials`

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,10 @@ func NewConfig() *Config {
 	if !cfg.WriteAWSCredentials {
 		cfg.WriteAWSCredentials = viper.GetBool("write_aws_credentials")
 	}
+	if cfg.WriteAWSCredentials {
+		// writing aws creds option implies "aws-credentials" format
+		cfg.Format = "aws-credentials"
+	}
 
 	tr := &http.Transport{
 		IdleConnTimeout: 30 * time.Second,


### PR DESCRIPTION
Write aws creds flag implies aws-credentials format and shouldn't have to be set explicitly.
Closes #39