### PR TITLE
pretty print http debug with  httputil

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,19 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 
 | Name | ENV var and .env file value | Command line flag | Description |
 |-------|-----------------------------|-------------------|-------------|
-| Okta Org Domain (**required**) | OKTA_ORG_DOMAIN | `--org-domain [value]` | Full domain hostname of the Okta org e.g. `test.okta.com` |
-| OIDC Client ID (**required**) | OKTA_OIDC_CLIENT_ID | `--oidc-client-id [value]` | See [Allowed Web SSO Client](#allowed-web-sso-client) |
-| Okta AWS Account Federation integration app ID (optional) | OKTA_AWS_ACCOUNT_FEDERATION_APP_ID | `--aws-acct-fed-app-id [value]` | See [AWS Account Federation integration app](#aws-account-federation-integration-app). This value is only required if the OIDC app doesn't have the `okta.apps.read` grant for whatever reason |
-| Preselect the AWS IAM Identity Provider ARN (optional) | AWS_IAM_IDP | `--aws-iam-idp [value]` | Preselects the IdP list to this preferred IAM Identity Provider. If there are other IdPs available they will not be listed. |
-| Preselects the AWS IAM Role ARN to assume (optional) | AWS_IAM_ROLE | `--aws-iam-role [value]` | Preselects the role list to this preferred IAM role for the given IAM Identity Provider. If there are other Roles available they will not be listed. |
-| AWS Session Duration (optional) | AWS_SESSION_DURATION | `--session-duration [value]` | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. |
-| Output format (optional) | FORMAT | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file |
-| Profile (optional) | PROFILE | `--profile [value]` | Default is `default`  |
-| Display QR Code (optional) | QR_CODE | `--qr-code` | `true` if flag is present  |
-| Automatically open the activation URL with the system web browser (optional) | OPEN_BROWSER | `--open-browser` | `true` if flag is present  |
-| Alternate AWS credentials file path (optional) | AWS_CREDENTIALS | `--aws-credentials` | Path to alternative credentials file other than AWS CLI default |
-| Write to the AWS credentials file (optional). Default formatting is to append and not modify the file beyond adding new lines. WARNING: When enabled, writing can inadvertently remove dangling comments and extraneous formatting from the creds file. | WRITE_AWS_CREDENTIALS | `--write-aws-credentials` | `true` if flag is present  |
+| Okta Org Domain (**required**) | `OKTA_ORG_DOMAIN` | `--org-domain [value]` | Full domain hostname of the Okta org e.g. `test.okta.com` |
+| OIDC Client ID (**required**) | `OKTA_OIDC_CLIENT_ID` | `--oidc-client-id [value]` | See [Allowed Web SSO Client](#allowed-web-sso-client) |
+| Okta AWS Account Federation integration app ID (optional) | `OKTA_AWS_ACCOUNT_FEDERATION_APP_ID` | `--aws-acct-fed-app-id [value]` | See [AWS Account Federation integration app](#aws-account-federation-integration-app). This value is only required if the OIDC app doesn't have the `okta.apps.read` grant for whatever reason |
+| Preselect the AWS IAM Identity Provider ARN (optional) | `AWS_IAM_IDP` | `--aws-iam-idp [value]` | Preselects the IdP list to this preferred IAM Identity Provider. If there are other IdPs available they will not be listed. |
+| Preselects the AWS IAM Role ARN to assume (optional) | `AWS_IAM_ROLE` | `--aws-iam-role [value]` | Preselects the role list to this preferred IAM role for the given IAM Identity Provider. If there are other Roles available they will not be listed. |
+| AWS Session Duration (optional) | `AWS_SESSION_DURATION` | `--session-duration [value]` | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. |
+| Output format (optional) | `FORMAT` | `--format [value]` | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file |
+| Profile (optional) | `PROFILE` | `--profile [value]` | Default is `default`  |
+| Display QR Code (optional) | `QR_CODE` | `--qr-code` | `true` if flag is present  |
+| Automatically open the activation URL with the system web browser (optional) | `OPEN_BROWSER` | `--open-browser` | `true` if flag is present  |
+| Alternate AWS credentials file path (optional) | `AWS_CREDENTIALS` | `--aws-credentials` | Path to alternative credentials file other than AWS CLI default |
+| Write to the AWS credentials file (optional). Default formatting is to append and not modify the file beyond adding new lines. WARNING: When enabled, writing can inadvertently remove dangling comments and extraneous formatting from the creds file. | `WRITE_AWS_CREDENTIALS` | `--write-aws-credentials` | `true` if flag is present  |
+| Verbosely print all API calls/responses to the screen | `DEBUG_API_CALLS` | `--debug-api-calls` | `true` if flag is present  |
 
 ### Allowed Web SSO Client
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -136,6 +136,13 @@ func init() {
 			usage:  fmt.Sprintf("Write the created/updated profile to the %q file. WARNING: This can inadvertently remove dangling comments and extraneous formatting from the creds file.", awsCredentialsFilename),
 			envVar: "WRITE_AWS_CREDENTIALS",
 		},
+		{
+			name:   "debug-api-calls",
+			short:  "x",
+			value:  false,
+			usage:  "Verbosely print all API calls/responses to the screen",
+			envVar: "DEBUG_API_CALLS",
+		},
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	AWSCredentials      string
 	WriteAWSCredentials bool
 	OpenBrowser         bool
+	DebugAPICalls       bool
 	HTTPClient          *http.Client
 }
 
@@ -66,6 +67,7 @@ func NewConfig() *Config {
 		OpenBrowser:         viper.GetBool("open-browser"),
 		AWSCredentials:      viper.GetString("aws-credentials"),
 		WriteAWSCredentials: viper.GetBool("write-aws-credentials"),
+		DebugAPICalls:       viper.GetBool("debug-api-calls"),
 	}
 	if cfg.Format == "" {
 		cfg.Format = "env-var"
@@ -118,11 +120,11 @@ func NewConfig() *Config {
 		cfg.Format = "aws-credentials"
 	}
 
-	tr := &http.Transport{
-		IdleConnTimeout: 30 * time.Second,
+	if !cfg.DebugAPICalls {
+		cfg.DebugAPICalls = viper.GetBool("debug-api-calls")
 	}
 	httpClient := &http.Client{
-		Transport: tr,
+		Transport: newConfigTransport(cfg.DebugAPICalls),
 		Timeout:   time.Second * time.Duration(60),
 	}
 	cfg.HTTPClient = httpClient

--- a/internal/config/net.go
+++ b/internal/config/net.go
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2022-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"time"
+)
+
+func debugRequest(req *http.Request) {
+	if req == nil {
+		return
+	}
+	reqData, err := httputil.DumpRequest(req, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logReqMsg, req.RequestURI, prettyPrintJSONLines(reqData))
+	} else {
+		log.Printf("[ERROR] %s API Request error: %#v", req.RequestURI, err)
+	}
+}
+
+func debugResponse(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	respData, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logRespMsg, resp.Request.RequestURI, prettyPrintJSONLines(respData))
+	} else {
+		log.Printf("[ERROR] %s API Response error: %#v", resp.Request.RequestURI, err)
+	}
+}
+
+// prettyPrintJSONLines iterates through a []byte line-by-line, transforming any
+// lines that are complete json into pretty-printed json.
+func prettyPrintJSONLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			_ = json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
+
+type configTransport struct {
+	rt    http.RoundTripper
+	debug bool
+}
+
+func newConfigTransport(debug bool) *configTransport {
+	ct := configTransport{
+		rt: &http.Transport{
+			IdleConnTimeout: 30 * time.Second,
+		},
+		debug: debug,
+	}
+
+	return &ct
+}
+
+func (ct *configTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if ct.debug {
+		debugRequest(r)
+	}
+	resp, err := ct.rt.RoundTrip(r)
+	if ct.debug {
+		debugResponse(resp)
+	}
+
+	return resp, err
+}

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -274,7 +274,8 @@ func (s *SessionToken) renderCredential(ac *oaws.Credential) error {
 // fetchAWSCredentialWithSAMLRole Get AWS Credentials with an STS Assume Role With SAML AWS
 // API call.
 func (s *SessionToken) fetchAWSCredentialWithSAMLRole(iar *idpAndRole, assertion string) (credential *oaws.Credential, err error) {
-	sess, err := session.NewSession()
+	awsCfg := aws.NewConfig().WithHTTPClient(s.config.HTTPClient)
+	sess, err := session.NewSession(awsCfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use golang httputil to verbosely print all API calls and response including urls, headers, bodies to screen.