### PR TITLE
Return underlying Error if present in fetchWebSSO()

### DIFF
--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -538,11 +538,7 @@ func (s *SessionToken) fetchSSOWebToken(clientID, awsFedAppID string, at *access
 			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
 		}
 
-<<<<<<< HEAD
 		return nil, fmt.Errorf("fetching SSO web token received API response %q, error: %q, description: %q",
-=======
-		return nil, fmt.Errorf("fetching SSO web token received API response %q\nerror: %q, description: %q\n",
->>>>>>> 6e3357744d9880de7d2949151d144223223b7859
 			resp.Status, apiErr.Error, apiErr.ErrorDescription)
 	}
 

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -538,7 +538,7 @@ func (s *SessionToken) fetchSSOWebToken(clientID, awsFedAppID string, at *access
 			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
 		}
 
-		return nil, fmt.Errorf("fetching SSO web token received API response %q\nerror: %q, description: %q\n",
+		return nil, fmt.Errorf("fetching SSO web token received API response %q, error: %q, description: %q",
 			resp.Status, apiErr.Error, apiErr.ErrorDescription)
 	}
 

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -525,23 +525,21 @@ func (s *SessionToken) fetchSSOWebToken(clientID, awsFedAppID string, at *access
 	if err != nil {
 		return nil, err
 	}
+
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
-		} else {
-			errStruct := struct {
-				Error            string `json:"error"`
-				ErrorDescription string `json:"error_description"`
-			}{}
-			err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&errStruct)
-			if err != nil {
-				return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
-			} else {
-				return nil, fmt.Errorf("fetching SSO web token received API response %q\nerror: %q, description: %q\n",
-					resp.Status, errStruct.Error, errStruct.ErrorDescription)
-			}
 		}
+
+		var apiErr apiError
+		err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&apiErr)
+		if err != nil {
+			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
+		}
+
+		return nil, fmt.Errorf("fetching SSO web token received API response %q\nerror: %q, description: %q\n",
+			resp.Status, apiErr.Error, apiErr.ErrorDescription)
 	}
 
 	bodyBytes, _ := io.ReadAll(resp.Body)

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -526,7 +526,22 @@ func (s *SessionToken) fetchSSOWebToken(clientID, awsFedAppID string, at *access
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
+		} else {
+			errStruct := struct {
+				Error            string `json:"error"`
+				ErrorDescription string `json:"error_description"`
+			}{}
+			err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&errStruct)
+			if err != nil {
+				return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
+			} else {
+				return nil, fmt.Errorf("fetching SSO web token received API response %q\nerror: %q, description: %q\n",
+					resp.Status, errStruct.Error, errStruct.ErrorDescription)
+			}
+		}
 	}
 
 	bodyBytes, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
As is when running the aws cli and an error is returned during the `fetchWebSSO()` call only the http error code is returned,
`Error: fetching SSO web token received API response "400 Bad Request"`

Update the function to check if an error is returned and if so add it to the error message to be displayed,

Incorrectly configured app in Web SSO field of the AWS Federation Application now returns,
```
Open the following URL to begin Okta device authorization for the AWS CLI

https://emanor-oie.oktapreview.com/activate?user_code=VQPWSLVD

Error: fetching SSO web token received API response "400 Bad Request"
error: "invalid_grant", description: "The target audience app must be configured to allow the client to request a 'web_sso_token'."
```

If the AWS Federation App has a more restrictive authentication policy which fails now returns,
```
Open the following URL to begin Okta device authorization for the AWS CLI

https://emanor-oie.oktapreview.com/activate?user_code=NMRPRLQD

Error: fetching SSO web token received API response "400 Bad Request"
error: "invalid_grant", description: "The application's assurance requirements are not met by the 'subject_token'."
```