### PR TITLE
Fix setting/getting IDP ARN value when Role Value Pattern is used on AWS Federation App

### DIFF
--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -71,7 +71,7 @@ const (
 )
 
 type idpTemplateData struct {
-	IdP string
+	IDP string
 }
 type roleTemplateData struct {
 	Role string
@@ -367,7 +367,7 @@ func (s *SessionToken) promptForIDP(idps []string) (idp string, err error) {
 		}
 
 		idpData := idpTemplateData{
-			IdP: idp,
+			IDP: idp,
 		}
 		rich, _, err := core.RunTemplate(idpSelectedTemplate, idpData)
 		if err != nil {


### PR DESCRIPTION
When using multiple fed apps AND those apps are making use of "Role Value Pattern" for establishing the IdP ARN for the fed app. Tthe IdP ARN value will not be known during list apps (which is used to list apps in the ncurses menu). Instead, each app needs to be retrieved directly from the API (after initial listing) as its IdP ARN value is determined at that time by the Okta service.