### PR TITLE
prep v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.2.0 (January 24, 2023)
+
+### ENHANCEMENTS
+
+* `setx` output when in Windows environment [#49](https://github.com/okta/okta-aws-cli/pull/49), thanks [@monde](https://github.com/monde)!
+* `--write-aws-credentials` implies output format `aws-credentials` [#40](https://github.com/okta/okta-aws-cli/pull/40), thanks [@monde](https://github.com/monde)!
+* Verbose HTTP API call/resonse logging with `--debug-api-calls` flag [#43](https://github.com/okta/okta-aws-cli/pull/43), thanks [@monde](https://github.com/monde)!
+* Return underlying Error if present in fetchWebSSO() [#47](https://github.com/okta/okta-aws-cli/pull/47), thanks [@emanor-okta](https://github.com/emanor-okta)!
+
+### BUG FIXES
+
+* Fix setting/getting IDP ARN value when Role Value Pattern is used on AWS Federation App [#51](https://github.com/okta/okta-aws-cli/pull/51), thanks [@monde](https://github.com/monde)!
+* Accept `OPEN_BROWSER`, `WRITE_AWS_CREDENTALS` env vars  [#50](https://github.com/okta/okta-aws-cli/pull/50), thanks [@monde](https://github.com/monde)!
+
 ## 0.1.0 (December 21, 2022)
 
 First GA release

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	// Version foo
-	Version = "0.1.0"
+	// Version app version
+	Version = "0.2.0"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -316,11 +316,9 @@ func (s *SessionToken) fetchAWSCredentialWithSAMLRole(iar *idpAndRole, assertion
 func (s *SessionToken) promptForRole(idp string, roles []string) (role string, err error) {
 	switch {
 	case len(roles) == 1 || s.config.AWSIAMRole != "":
-		if s.config.AWSIAMRole != "" {
-			role = s.config.AWSIAMRole
-		} else {
+		role = s.config.AWSIAMRole
+		if len(roles) == 1 {
 			role = roles[0]
-
 		}
 		roleData := roleTemplateData{
 			Role: role,
@@ -357,9 +355,8 @@ func (s *SessionToken) promptForIDP(idps []string) (idp string, err error) {
 
 	switch {
 	case len(idps) == 1 || s.config.AWSIAMIdP != "":
-		if s.config.AWSIAMIdP != "" {
-			idp = s.config.AWSIAMIdP
-		} else {
+		idp = s.config.AWSIAMIdP
+		if len(idps) == 1 {
 			idp = idps[0]
 		}
 		if s.fedAppAlreadySelected {
@@ -515,18 +512,18 @@ func (s *SessionToken) fetchSSOWebToken(clientID, awsFedAppID string, at *access
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
+		baseErrStr := "fetching SSO web token received API response %q"
 		if err != nil {
-			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
+			return nil, fmt.Errorf(baseErrStr, resp.Status)
 		}
 
 		var apiErr apiError
 		err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&apiErr)
 		if err != nil {
-			return nil, fmt.Errorf("fetching SSO web token received API response %q", resp.Status)
+			return nil, fmt.Errorf(baseErrStr, resp.Status)
 		}
 
-		return nil, fmt.Errorf("fetching SSO web token received API response %q, error: %q, description: %q",
-			resp.Status, apiErr.Error, apiErr.ErrorDescription)
+		return nil, fmt.Errorf(baseErrStr+", error: %q, description: %q", resp.Status, apiErr.Error, apiErr.ErrorDescription)
 	}
 
 	bodyBytes, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
## 0.2.0 (January 24, 2023)

### ENHANCEMENTS

* `setx` output when in Windows environment [#49](https://github.com/okta/okta-aws-cli/pull/49), thanks [@monde](https://github.com/monde)!
* `--write-aws-credentials` implies output format `aws-credentials` [#40](https://github.com/okta/okta-aws-cli/pull/40), thanks [@monde](https://github.com/monde)!
* Verbose HTTP API call/resonse logging with `--debug-api-calls` flag [#43](https://github.com/okta/okta-aws-cli/pull/43), thanks [@monde](https://github.com/monde)!
* Return underlying Error if present in fetchWebSSO() [#47](https://github.com/okta/okta-aws-cli/pull/47), thanks [@emanor-okta](https://github.com/emanor-okta)!

### BUG FIXES

* Fix setting/getting IDP ARN value when Role Value Pattern is used on AWS Federation App [#51](https://github.com/okta/okta-aws-cli/pull/51), thanks [@monde](https://github.com/monde)!
* Accept `OPEN_BROWSER`, `WRITE_AWS_CREDENTALS` env vars  [#50](https://github.com/okta/okta-aws-cli/pull/50), thanks [@monde](https://github.com/monde)!