### PR TITLE
added proxy support to http client

### DIFF
--- a/internal/config/net.go
+++ b/internal/config/net.go
@@ -83,6 +83,7 @@ func newConfigTransport(debug bool) *configTransport {
 	ct := configTransport{
 		rt: &http.Transport{
 			IdleConnTimeout: 30 * time.Second,
+			Proxy:           http.ProxyFromEnvironment,
 		},
 		debug: debug,
 	}


### PR DESCRIPTION
Currently the http client is unable to function when initiated from behind a proxy. Adding http.ProxyFromEnvironment to the http.Transport allows the controlling of proxies via HTTP_PROXY and HTTPS_PROXY environment variables.