### PR TITLE
Remove an extra colon in usage text

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -206,7 +206,7 @@ func Execute() {
 }
 
 func resourceUsageTemplate() string {
-	return fmt.Sprintf(`%s:{{if .Runnable}}
+	return fmt.Sprintf(`%s{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 


### PR DESCRIPTION
*(I believe this is an "obvious fix" so I did not sign the [CLA](https://developer.okta.com/cla/).)*

This removes an extra colon after `Usage:` in the following output:

```
$ okta-aws-cli --help
okta-aws-cli - Okta federated identity for AWS CLI

Okta authentication for federated identity providers in support of AWS CLI.
okta-aws-cli handles authentication to the IdP and token exchange with AWS STS
to collect a proper IAM role for the AWS CLI operator.

Usage::
  okta-aws-cli [flags]

Flags:
  -a, --aws-acct-fed-app-id string   AWS Account Federation app ID
  -w, --aws-credentials string       Path to AWS credentials file, only valid with format "aws-credentials" (default "/home/linuxbrew/.aws/credentials")
  -i, --aws-iam-idp string           Preset IAM Identity Provider ARN
  -r, --aws-iam-role string          Preset IAM Role ARN
  -x, --debug-api-calls              Verbosely print all API calls/responses to the screen
  -f, --format string                Output format. [env-var|aws-credentials] (default "env-var")
  -h, --help                         help for okta-aws-cli
  -c, --oidc-client-id string        OIDC Client ID
  -b, --open-browser                 Automatically open the activation URL with the system web browser
  -o, --org-domain string            Okta Org Domain
  -p, --profile string               AWS Profile (default "default")
  -q, --qr-code                      Print QR Code of activation URL
  -s, --session-duration string      Session duration for role. (default "3600")
  -v, --version                      version for okta-aws-cli
  -z, --write-aws-credentials        Write the created/updated profile to the "/home/linuxbrew/.aws/credentials" file. WARNING: This can inadvertently remove dangling comments and extraneous formatting from the creds file.
```