### PR TITLE
AWS profiles in creds INI file w/ deprecated variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Display QR Code (optional) | `QR_CODE=true` | `--qr-code` | `true` if flag is present  |
 | Automatically open the activation URL with the system web browser (optional) | `OPEN_BROWSER=true` | `--open-browser` | `true` if flag is present  |
 | Alternate AWS credentials file path (optional) | `AWS_CREDENTIALS` | `--aws-credentials` | Path to alternative credentials file other than AWS CLI default |
-| Write to the AWS credentials file (optional). Default formatting is to append and not modify the file beyond adding new lines. WARNING: When enabled, writing can inadvertently remove dangling comments and extraneous formatting from the creds file. | `WRITE_AWS_CREDENTIALS=true` | `--write-aws-credentials` | `true` if flag is present  |
+| (Over)write the given profile to the AWS credentials file (optional). WARNING: When enabled, overwriting can inadvertently remove dangling comments and extraneous formatting from the creds file. | `WRITE_AWS_CREDENTIALS=true` | `--write-aws-credentials` | `true` if flag is present  |
 | Verbosely print all API calls/responses to the screen | `DEBUG_API_CALLS=true` | `--debug-api-calls` | `true` if flag is present  |
 
 ### Allowed Web SSO Client
@@ -344,9 +344,9 @@ configuration file that is dropped somewhere in the user's `$HOME` directory to
 operate the CLI.
 
 The Okta CLI is CLI flag and environment variable oriented and its default
-output is as environment variables. It can write to an AWS credentials file but
-only in append mode. It never risks interpreting and re-writing the AWS
-credentials file potentially corrupting other valuable credentials saved there.
+output is as environment variables. It can also write to AWS credentials file.
+The default writing option is an apped operation and can be explicitly set to
+overwrite previous values for a profile with the `--write-aws-credentials` flag.
 
 ### Versent saml2aws
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Automatically open the activation URL with the system web browser (optional) | `OPEN_BROWSER=true` | `--open-browser` | `true` if flag is present  |
 | Alternate AWS credentials file path (optional) | `AWS_CREDENTIALS` | `--aws-credentials` | Path to alternative credentials file other than AWS CLI default |
 | (Over)write the given profile to the AWS credentials file (optional). WARNING: When enabled, overwriting can inadvertently remove dangling comments and extraneous formatting from the creds file. | `WRITE_AWS_CREDENTIALS=true` | `--write-aws-credentials` | `true` if flag is present  |
+| Emit deprecated AWS variable `aws_security_token` with duplicated value from `aws_session_token` | `LEGACY_AWS_VARIABLES=true` | `--legacy-aws-variables` | `true` if flag is present  |
 | Verbosely print all API calls/responses to the screen | `DEBUG_API_CALLS=true` | `--debug-api-calls` | `true` if flag is present  |
 
 ### Allowed Web SSO Client

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -136,6 +136,13 @@ func init() {
 			envVar: config.WriteAWSCredentialsEnvVar,
 		},
 		{
+			name:   config.LegacyAWSVariablesFlag,
+			short:  "l",
+			value:  false,
+			usage:  "Emit deprecated AWS Security Token value. WARNING: AWS CLI deprecated this value in November 2014 and is no longer documented",
+			envVar: config.LegacyAWSVariablesEnvVar,
+		},
+		{
 			name:   config.DebugAPICallsFlag,
 			short:  "x",
 			value:  false,

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -22,3 +22,11 @@ type Credential struct {
 	SecretAccessKey string `ini:"aws_secret_access_key"`
 	SessionToken    string `ini:"aws_session_token"`
 }
+
+// LegacyCredential Convenience representation of an AWS credential.
+type LegacyCredential struct {
+	AccessKeyID     string `ini:"aws_access_key_id"`
+	SecretAccessKey string `ini:"aws_secret_access_key"`
+	SessionToken    string `ini:"aws_session_token"`
+	SecurityToken   string `ini:"aws_security_token"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,8 @@ const (
 	SessionDurationFlag = "session-duration"
 	// WriteAWSCredentialsFlag cli flag const
 	WriteAWSCredentialsFlag = "write-aws-credentials"
+	// LegacyAWSVariablesFlag cli flag const
+	LegacyAWSVariablesFlag = "legacy-aws-variables"
 
 	// AWSCredentialsEnvVar env var const
 	AWSCredentialsEnvVar = "AWS_CREDENTIALS"
@@ -87,6 +89,8 @@ const (
 	WriteAWSCredentialsEnvVar = "WRITE_AWS_CREDENTIALS"
 	// DebugAPICallsEnvVar env var const
 	DebugAPICallsEnvVar = "DEBUG_API_CALLS"
+	// LegacyAWSVariablesEnvVar env var const
+	LegacyAWSVariablesEnvVar = "LEGACY_AWS_VARIABLES"
 )
 
 // Config A config object for the CLI
@@ -104,6 +108,7 @@ type Config struct {
 	WriteAWSCredentials bool
 	OpenBrowser         bool
 	DebugAPICalls       bool
+	LegacyAWSVariables  bool
 	HTTPClient          *http.Client
 }
 
@@ -120,6 +125,7 @@ func NewConfig() *Config {
 		DebugAPICalls:       viper.GetBool(DebugAPICallsFlag),
 		FedAppID:            viper.GetString(AWSAcctFedAppIDFlag),
 		Format:              viper.GetString(FormatFlag),
+		LegacyAWSVariables:  viper.GetBool(LegacyAWSVariablesFlag),
 		OIDCAppID:           viper.GetString(OIDCClientIDFlag),
 		OpenBrowser:         viper.GetBool(OpenBrowserFlag),
 		OrgDomain:           viper.GetString(OrgDomainFlag),
@@ -177,13 +183,14 @@ func NewConfig() *Config {
 		// writing aws creds option implies "aws-credentials" format
 		cfg.Format = AWSCredentialsFormat
 	}
-
 	if !cfg.OpenBrowser {
 		cfg.OpenBrowser = viper.GetBool(downCase(OpenBrowserEnvVar))
 	}
-
 	if !cfg.DebugAPICalls {
 		cfg.DebugAPICalls = viper.GetBool(downCase(DebugAPICallsEnvVar))
+	}
+	if !cfg.LegacyAWSVariables {
+		cfg.LegacyAWSVariables = viper.GetBool(downCase(LegacyAWSVariablesEnvVar))
 	}
 	httpClient := &http.Client{
 		Transport: newConfigTransport(cfg.DebugAPICalls),

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -53,8 +53,8 @@ func ensureConfigExists(filename string, profile string) error {
 	return nil
 }
 
-func saveProfile(filename, profile string, awsCreds *aws.Credential) error {
-	config, err := updateConfig(filename, profile, awsCreds)
+func saveProfile(filename, profile string, awsCreds *aws.Credential, legacyVars bool) error {
+	config, err := updateConfig(filename, profile, awsCreds, legacyVars)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func saveProfile(filename, profile string, awsCreds *aws.Credential) error {
 	return nil
 }
 
-func updateConfig(filename, profile string, awsCreds *aws.Credential) (config *ini.File, err error) {
+func updateConfig(filename, profile string, awsCreds *aws.Credential, legacyVars bool) (config *ini.File, err error) {
 	config, err = ini.Load(filename)
 	if err != nil {
 		return
@@ -78,21 +78,35 @@ func updateConfig(filename, profile string, awsCreds *aws.Credential) (config *i
 	if err != nil {
 		return
 	}
-	err = iniProfile.ReflectFrom(awsCreds)
+	var creds interface{}
+	if legacyVars {
+		creds = &aws.LegacyCredential{
+			AccessKeyID:     awsCreds.AccessKeyID,
+			SecretAccessKey: awsCreds.SecretAccessKey,
+			SessionToken:    awsCreds.SessionToken,
+			SecurityToken:   awsCreds.SessionToken,
+		}
+	} else {
+		creds = awsCreds
+	}
+	err = iniProfile.ReflectFrom(creds)
 	if err != nil {
 		return
 	}
 
-	return updateINI(config, profile)
+	return updateINI(config, profile, legacyVars)
 }
 
 // updateIni will comment out any keys that are not "aws_access_key_id",
 // "aws_secret_access_key", or "aws_session_token"
-func updateINI(config *ini.File, profile string) (*ini.File, error) {
+func updateINI(config *ini.File, profile string, legacyVars bool) (*ini.File, error) {
 	ignore := []string{
 		"aws_access_key_id",
 		"aws_secret_access_key",
 		"aws_session_token",
+	}
+	if legacyVars {
+		ignore = append(ignore, "aws_security_token")
 	}
 	section := config.Section(profile)
 	comments := []string{}
@@ -118,16 +132,23 @@ func updateINI(config *ini.File, profile string) (*ini.File, error) {
 	if len(comments) > 0 {
 		fmt.Fprintf(os.Stderr, "WARNING: Commented out %q profile keys \"%s\". Uncomment if third party tools use these values.\n", profile, strings.Join(comments, "\", \""))
 	}
+	if legacyVars {
+		fmt.Fprintf(os.Stderr, "WARNING: %q includes legacy variable \"aws_security_token\". Update tools making use of this deprecated value.", profile)
+	}
 
 	return config, nil
 }
 
 // AWSCredentialsFile AWS credentials file output formatter
-type AWSCredentialsFile struct{}
+type AWSCredentialsFile struct {
+	LegacyAWSVariables bool
+}
 
 // NewAWSCredentialsFile Creates a new
-func NewAWSCredentialsFile() *AWSCredentialsFile {
-	return &AWSCredentialsFile{}
+func NewAWSCredentialsFile(legacyVars bool) *AWSCredentialsFile {
+	return &AWSCredentialsFile{
+		LegacyAWSVariables: legacyVars,
+	}
 }
 
 // Output Satisfies the Outputter interface and appends AWS credentials to
@@ -149,13 +170,26 @@ func (e *AWSCredentialsFile) appendConfig(c *config.Config, ac *aws.Credential) 
 		_ = f.Close()
 	}()
 
-	creds := `
+	var creds string
+
+	if e.LegacyAWSVariables {
+		creds = `
+[%s]
+aws_access_key_id = %s
+aws_secret_access_key = %s
+aws_session_token = %s
+aws_security_token = %s
+`
+		creds = fmt.Sprintf(creds, c.Profile, ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken, ac.SessionToken)
+	} else {
+		creds = `
 [%s]
 aws_access_key_id = %s
 aws_secret_access_key = %s
 aws_session_token = %s
 `
-	creds = fmt.Sprintf(creds, c.Profile, ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken)
+		creds = fmt.Sprintf(creds, c.Profile, ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken)
+	}
 	_, err = f.WriteString(creds)
 	if err != nil {
 		return err
@@ -176,7 +210,7 @@ func (e *AWSCredentialsFile) writeConfig(c *config.Config, ac *aws.Credential) e
 		return err
 	}
 
-	return saveProfile(filename, profile, ac)
+	return saveProfile(filename, profile, ac, e.LegacyAWSVariables)
 }
 
 func contains(ignore []string, name string) bool {

--- a/internal/output/envvar.go
+++ b/internal/output/envvar.go
@@ -25,11 +25,15 @@ import (
 )
 
 // EnvVar Environment Variable output formatter
-type EnvVar struct{}
+type EnvVar struct {
+	LegacyAWSVariables bool
+}
 
 // NewEnvVar Creates a new EnvVar
-func NewEnvVar() *EnvVar {
-	return &EnvVar{}
+func NewEnvVar(legacyVars bool) *EnvVar {
+	return &EnvVar{
+		LegacyAWSVariables: legacyVars,
+	}
 }
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as shell
@@ -39,10 +43,16 @@ func (e *EnvVar) Output(c *config.Config, ac *aws.Credential) error {
 		fmt.Printf("setx AWS_ACCESS_KEY_ID %s\n", ac.AccessKeyID)
 		fmt.Printf("setx AWS_SECRET_ACCESS_KEY %s\n", ac.SecretAccessKey)
 		fmt.Printf("setx AWS_SESSION_TOKEN %s\n", ac.SessionToken)
+		if e.LegacyAWSVariables {
+			fmt.Printf("setx AWS_SECURITY_TOKEN %s\n", ac.SessionToken)
+		}
 	} else {
 		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", ac.AccessKeyID)
 		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", ac.SecretAccessKey)
 		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", ac.SessionToken)
+		if e.LegacyAWSVariables {
+			fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", ac.SessionToken)
+		}
 	}
 
 	return nil

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -275,9 +275,9 @@ func (s *SessionToken) renderCredential(ac *oaws.Credential) error {
 	var o output.Outputter
 	switch s.config.Format {
 	case config.AWSCredentialsFormat:
-		o = output.NewAWSCredentialsFile()
+		o = output.NewAWSCredentialsFile(s.config.LegacyAWSVariables)
 	default:
-		o = output.NewEnvVar()
+		o = output.NewEnvVar(s.config.LegacyAWSVariables)
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 


### PR DESCRIPTION
okta-aws-cli writes AWS creds variables in session token orientation as `aws_session_token`, `aws_access_key_id`,`aws_secret_access_key`.  This is done for the given profile of an INI file when running in write aws creds mode. Other tools may still be setting obsolete AWS creds variables ([AWS deprecated `aws_security_token` in November 2014, it is not referred to any any public AWS CLI documentation](https://github.com/aws/aws-cli/commit/ff5987ebc6c852fcfcf8c975847ee9185de1610d)) that conflict with modern usage. Therefore, instead of ignoring or destroying previous unnecessary values just comment them out so `$ aws [op] [args]` executes without error.

## Standard behavior: `$ okta-aws-cli --write-aws-credentials`

Given aws creds
```
[default]
random                = thing
aws_session_token     = abc
aws_access_key_id     = def
aws_secret_access_key = ghi
aws_security_token    = jkl
```
Given command `$ okta-aws-cli --write-aws-credentials`

Creds file will be updated as
```
[default]
# random                = thing
aws_session_token     = xxx
aws_access_key_id     = yyy
aws_secret_access_key = zzz
# aws_security_token    = jkl
```

The UX will look something like:
```
$ okta-aws-cli --oidc-client-id abc123 --org-domain test.oktapreview.com --open-browser --write-aws-credentials
System web browser will open the following URL to begin Okta device authorization for the AWS CLI

https://test.oktapreview.com/activate?user_code=GXZVSBSF

? Choose an IdP: AWS Account Federation (arn:aws:iam::123:saml-provider/Mondragon_AWS_CLI)
? Choose a Role: arn:aws:iam::456:role/MMondragon_S3_Read
WARNING: Commented out "default" profile keys "random", "aws_security_token". Uncomment if third party tools use these values.
Updated profile "default" in credentials file "/Users/user/.aws/credentials".
```

## Legacy supporting behavior `$ okta-aws-cli --write-aws-credentials --legacy-aws-variables`

Given aws creds

```
[default]
random                = thing
aws_session_token     = abc
aws_security_token    = abc
aws_access_key_id     = def
aws_secret_access_key = ghi
```
Given command `$ okta-aws-cli --write-aws-credentials --legacy-aws-variables`

Creds file will be updated as
```
[default]
# random                = thing
aws_session_token     = xxx
aws_security_token    = xxx
aws_access_key_id     = yyy
aws_secret_access_key = zzz
```
The UX will look something like:
```
$ okta-aws-cli --oidc-client-id abc123 --org-domain test.oktapreview.com --open-browser --write-aws-credentials --legacy-aws-variables
System web browser will open the following URL to begin Okta device authorization for the AWS CLI

https://test.oktapreview.com/activate?user_code=GXZVSBSF

? Choose an IdP: AWS Account Federation (arn:aws:iam::123:saml-provider/Mondragon_AWS_CLI)
? Choose a Role: arn:aws:iam::456:role/MMondragon_S3_Read
WARNING: Commented out "default" profile keys "random". Uncomment if third party tools use these values.
WARNING: "default" profile includes legacy variable "aws_security_token". Update tools making use of this deprecated value.
Updated profile "default" in credentials file "/Users/user/.aws/credentials".
```


