### PR TITLE
Send browser command stdout to stderr

### DIFF
--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -561,6 +561,7 @@ func (s *SessionToken) promptAuthentication(da *deviceAuthorization) {
 	fmt.Fprintf(os.Stderr, prompt, openMsg, qrCode, da.VerificationURIComplete)
 
 	if s.config.OpenBrowser() {
+		brwsr.Stdout = os.Stderr
 		if err := brwsr.OpenURL(da.VerificationURIComplete); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to open activation URL with system browser: %v\n", err)
 		}


### PR DESCRIPTION
This way any output the browser command might print won't cause issues when running `eval $(okta-aws-cli)`.

This aims to resolve #91 