### PR TITLE
Collect all IDPs/Roles at once

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -102,6 +102,12 @@ func init() {
 			envVar: config.ProfileEnvVar,
 		},
 		{
+			name:   config.AllProfilesFlag,
+			value:  false,
+			usage:  "Collect and write all profiles",
+			envVar: config.AllProfilesEnvVar,
+		},
+		{
 			name:   config.FormatFlag,
 			short:  "f",
 			value:  "env-var",

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -21,7 +21,15 @@ type Credential struct {
 	AccessKeyID     string `ini:"aws_access_key_id"`
 	SecretAccessKey string `ini:"aws_secret_access_key"`
 	SessionToken    string `ini:"aws_session_token"`
+
+	profile string
 }
+
+// SetProfile sets the profile name associated with this AWS credential.
+func (c *Credential) SetProfile(s string) { c.profile = s }
+
+// Profile returns the profile name associated with this AWS credential.
+func (c Credential) Profile() string { return c.profile }
 
 // LegacyCredential Convenience representation of an AWS credential.
 type LegacyCredential struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,8 @@ const (
 	OrgDomainFlag = "org-domain"
 	// ProfileFlag cli flag const
 	ProfileFlag = "profile"
+	// AllProfilesFlag cli flag const
+	AllProfilesFlag = "all-profiles"
 	// QRCodeFlag cli flag const
 	QRCodeFlag = "qr-code"
 	// SessionDurationFlag cli flag const
@@ -84,6 +86,8 @@ const (
 	OpenBrowserEnvVar = "OPEN_BROWSER"
 	// ProfileEnvVar env var const
 	ProfileEnvVar = "PROFILE"
+	// AllProfilesEnvVar env var const
+	AllProfilesEnvVar = "ALL_PROFILES"
 	// QRCodeEnvVar env var const
 	QRCodeEnvVar = "QR_CODE"
 	// WriteAWSCredentialsEnvVar env var const
@@ -104,6 +108,7 @@ type Config struct {
 	awsSessionDuration  int64
 	format              string
 	profile             string
+	allProfiles         bool
 	qrCode              bool
 	awsCredentials      string
 	writeAWSCredentials bool
@@ -123,6 +128,7 @@ type Attributes struct {
 	AWSSessionDuration  int64
 	Format              string
 	Profile             string
+	AllProfiles         bool
 	QRCode              bool
 	AWSCredentials      string
 	WriteAWSCredentials bool
@@ -152,6 +158,7 @@ func NewConfig(attrs Attributes) (*Config, error) {
 		awsIAMRole:          attrs.AWSIAMRole,
 		format:              attrs.Format,
 		profile:             attrs.Profile,
+		allProfiles:         attrs.AllProfiles,
 		qrCode:              attrs.QRCode,
 		awsCredentials:      attrs.AWSCredentials,
 		writeAWSCredentials: attrs.WriteAWSCredentials,
@@ -196,6 +203,7 @@ func readConfig() (Attributes, error) {
 		OpenBrowser:         viper.GetBool(OpenBrowserFlag),
 		OrgDomain:           viper.GetString(OrgDomainFlag),
 		Profile:             viper.GetString(ProfileFlag),
+		AllProfiles:         viper.GetBool(AllProfilesFlag),
 		QRCode:              viper.GetBool(QRCodeFlag),
 		WriteAWSCredentials: viper.GetBool(WriteAWSCredentialsFlag),
 	}
@@ -266,7 +274,7 @@ func readConfig() (Attributes, error) {
 		attrs.WriteAWSCredentials = viper.GetBool(downCase(WriteAWSCredentialsEnvVar))
 	}
 	// TODU
-	if attrs.WriteAWSCredentials {
+	if attrs.AllProfiles || attrs.WriteAWSCredentials {
 		// writing aws creds option implies "aws-credentials" format
 		attrs.Format = AWSCredentialsFormat
 	}
@@ -384,6 +392,17 @@ func (c *Config) Profile() string {
 // SetProfile --
 func (c *Config) SetProfile(profile string) error {
 	c.profile = profile
+	return nil
+}
+
+// AllProfiles --
+func (c *Config) AllProfiles() bool {
+	return c.allProfiles
+}
+
+// SetAllProfiles --
+func (c *Config) SetAllProfiles(all bool) error {
+	c.allProfiles = all
 	return nil
 }
 

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -170,6 +170,11 @@ func (e *AWSCredentialsFile) appendConfig(c *config.Config, ac *aws.Credential) 
 		_ = f.Close()
 	}()
 
+	profile := ac.Profile()
+	if len(profile) == 0 {
+		profile = c.Profile()
+	}
+
 	var creds string
 
 	if e.LegacyAWSVariables {
@@ -180,7 +185,7 @@ aws_secret_access_key = %s
 aws_session_token = %s
 aws_security_token = %s
 `
-		creds = fmt.Sprintf(creds, c.Profile(), ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken, ac.SessionToken)
+		creds = fmt.Sprintf(creds, profile, ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken, ac.SessionToken)
 	} else {
 		creds = `
 [%s]
@@ -188,7 +193,7 @@ aws_access_key_id = %s
 aws_secret_access_key = %s
 aws_session_token = %s
 `
-		creds = fmt.Sprintf(creds, c.Profile(), ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken)
+		creds = fmt.Sprintf(creds, profile, ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken)
 	}
 	_, err = f.WriteString(creds)
 	if err != nil {
@@ -196,14 +201,17 @@ aws_session_token = %s
 	}
 	_ = f.Sync()
 
-	fmt.Fprintf(os.Stderr, "Appended profile %q to %s\n", c.Profile(), c.AWSCredentials())
+	fmt.Fprintf(os.Stderr, "Appended profile %q to %s\n", profile, c.AWSCredentials())
 
 	return nil
 }
 
 func (e *AWSCredentialsFile) writeConfig(c *config.Config, ac *aws.Credential) error {
 	filename := c.AWSCredentials()
-	profile := c.Profile()
+	profile := ac.Profile()
+	if len(profile) == 0 {
+		profile = c.Profile()
+	}
 
 	err := ensureConfigExists(filename, profile)
 	if err != nil {

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -372,24 +372,22 @@ func (s *SessionToken) fetchAllAWSCredentialsWithSAMLRole(idpRolesMap map[string
 		for _, role := range roles {
 			iar := &idpAndRole{idp, role}
 			wg.Add(1)
-			go func() error {
+			go func() {
 				defer wg.Done()
 				ac, err := s.fetchAWSCredentialWithSAMLRole(iar, assertion)
 				if err != nil {
 					fmt.Fprintf(os.Stderr,
 						"failed to fetch AWS creds from role %+v: %s\n", *iar, err)
-					return nil
+					return
 				}
 				c <- ac
-				return nil
 			}()
 		}
 	}
 
-	go func() error {
+	go func() {
 		wg.Wait()
 		close(c)
-		return nil
 	}()
 
 	return c

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -561,6 +561,7 @@ func (s *SessionToken) promptAuthentication(da *deviceAuthorization) {
 	fmt.Fprintf(os.Stderr, prompt, openMsg, qrCode, da.VerificationURIComplete)
 
 	if s.config.OpenBrowser() {
+		brwsr.Stdout = os.Stderr
 		if err := brwsr.OpenURL(da.VerificationURIComplete); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to open activation URL with system browser: %v\n", err)
 		}


### PR DESCRIPTION
This change adds a new config flag `--all-profiles` (and env variable `ALL_PROFILES`). When this is given, it will cause all IDP/Roles available to the user to be fetched. 

This aims to resolve #36.