### PR TITLE
Bringing in @tim-fitzgerald's PR 56 `x_security_token_expires` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | Alternate AWS credentials file path (optional) | `OKTA_AWSCLI_AWS_CREDENTIALS` | `--aws-credentials` | Path to alternative credentials file other than AWS CLI default |
 | (Over)write the given profile to the AWS credentials file (optional). WARNING: When enabled, overwriting can inadvertently remove dangling comments and extraneous formatting from the creds file. | `OKTA_AWSCLI_WRITE_AWS_CREDENTIALS=true` | `--write-aws-credentials` | `true` if flag is present  |
 | Emit deprecated AWS variable `aws_security_token` with duplicated value from `aws_session_token` | `OKTA_AWSCLI_LEGACY_AWS_VARIABLES=true` | `--legacy-aws-variables` | `true` if flag is present  |
+| Emit expiry timestamp `x_security_token_expires` in RFC3339 format for the session/security token (AWS credentials file only) | `OKTA_AWSCLI_EXPIRY_AWS_VARIABLES=true` | `--expiry-aws-variables` | `true` if flag is present  |
 | Verbosely print all API calls/responses to the screen | `OKTA_AWSCLI_DEBUG_API_CALLS=true` | `--debug-api-calls` | `true` if flag is present  |
 | HTTP/HTTPS Proxy support | `HTTP_PROXY` or `HTTPS_PROXY` | n/a | HTTP/HTTPS URL of proxy service (based on golang [net/http/httpproxy](https://pkg.go.dev/golang.org/x/net/http/httpproxy) package) |
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Wrote profile "test" to /Users/mikemondragon/.aws/credentials
 2018-04-04 11:56:00 test-bucket
 2021-06-10 12:47:11 mah-bucket
 ```
+Note: Writing to the AWS credentials file will include the `x_security_token_expires` value in RFC3339 format. This allows tools dependent on valid AWS credentials to validate if they are expired or not, and potentially trigger a refresh if needed.
 
 **NOTE**: the Okta AWS CLI will only append to the AWS credentials file. Be sure to
 comment out or remove previous named profiles from the credentials file.

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -144,8 +144,15 @@ func init() {
 			envVar: config.LegacyAWSVariablesEnvVar,
 		},
 		{
-			name:   config.DebugAPICallsFlag,
+			name:   config.ExpiryAWSVariablesFlag,
 			short:  "x",
+			value:  false,
+			usage:  "Emit x_security_token_expires value in profile block of AWS credentials file",
+			envVar: config.ExpiryAWSVariablesEnvVar,
+		},
+		{
+			name:   config.DebugAPICallsFlag,
+			short:  "d",
 			value:  false,
 			usage:  "Verbosely print all API calls/responses to the screen",
 			envVar: config.DebugAPICallsEnvVar,

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	gopkg.in/ini.v1 v1.67.0
 )
 
+require github.com/ompluscator/dynamic-struct v1.4.0 // indirect
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/ompluscator/dynamic-struct v1.4.0 h1:I/Si9LZtItSwiTMe7vosEuIu2TKdOvWbE3R/lokpN4Q=
+github.com/ompluscator/dynamic-struct v1.4.0/go.mod h1:ADQ1+6Ox1D+ntuNwTHyl1NvpAqY2lBXPSPbcO4CJdeA=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -16,11 +16,14 @@
 
 package aws
 
+import "time"
+
 // Credential Convenience representation of an AWS credential.
 type Credential struct {
-	AccessKeyID     string `ini:"aws_access_key_id"`
-	SecretAccessKey string `ini:"aws_secret_access_key"`
-	SessionToken    string `ini:"aws_session_token"`
+	AccessKeyID     string    `ini:"aws_access_key_id"`
+	SecretAccessKey string    `ini:"aws_secret_access_key"`
+	SessionToken    string    `ini:"aws_session_token"`
+	Expiration      time.Time `ini:"x_security_token_expires"`
 }
 
 // LegacyCredential Convenience representation of an AWS credential.

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -16,20 +16,9 @@
 
 package aws
 
-import "time"
-
 // Credential Convenience representation of an AWS credential.
 type Credential struct {
-	AccessKeyID     string    `ini:"aws_access_key_id"`
-	SecretAccessKey string    `ini:"aws_secret_access_key"`
-	SessionToken    string    `ini:"aws_session_token"`
-	Expiration      time.Time `ini:"x_security_token_expires"`
-}
-
-// LegacyCredential Convenience representation of an AWS credential.
-type LegacyCredential struct {
 	AccessKeyID     string `ini:"aws_access_key_id"`
 	SecretAccessKey string `ini:"aws_secret_access_key"`
 	SessionToken    string `ini:"aws_session_token"`
-	SecurityToken   string `ini:"aws_security_token"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,8 @@ const (
 	WriteAWSCredentialsFlag = "write-aws-credentials"
 	// LegacyAWSVariablesFlag cli flag const
 	LegacyAWSVariablesFlag = "legacy-aws-variables"
+	// ExpiryAWSVariablesFlag cli flag const
+	ExpiryAWSVariablesFlag = "expiry-aws-variables"
 
 	// AWSCredentialsEnvVar env var const
 	AWSCredentialsEnvVar = "OKTA_AWSCLI_AWS_CREDENTIALS"
@@ -96,6 +98,8 @@ const (
 	DebugAPICallsEnvVar = "OKTA_AWSCLI_DEBUG_API_CALLS"
 	// LegacyAWSVariablesEnvVar env var const
 	LegacyAWSVariablesEnvVar = "OKTA_AWSCLI_LEGACY_AWS_VARIABLES"
+	// ExpiryAWSVariablesEnvVar env var const
+	ExpiryAWSVariablesEnvVar = "OKTA_AWSCLI_EXPIRY_AWS_VARIABLES"
 
 	// CannotBeBlankErrMsg error message const
 	CannotBeBlankErrMsg = "cannot be blank"
@@ -120,6 +124,7 @@ type Config struct {
 	openBrowser         bool
 	debugAPICalls       bool
 	legacyAWSVariables  bool
+	expiryAWSVariables  bool
 	httpClient          *http.Client
 }
 
@@ -146,6 +151,7 @@ type Attributes struct {
 	OpenBrowser         bool
 	DebugAPICalls       bool
 	LegacyAWSVariables  bool
+	ExpiryAWSVariables  bool
 }
 
 // CreateConfig Creates a new config gathering values in this order of precedence:
@@ -175,6 +181,7 @@ func NewConfig(attrs Attributes) (*Config, error) {
 		openBrowser:         attrs.OpenBrowser,
 		debugAPICalls:       attrs.DebugAPICalls,
 		legacyAWSVariables:  attrs.LegacyAWSVariables,
+		expiryAWSVariables:  attrs.ExpiryAWSVariables,
 	}
 	err = cfg.SetOrgDomain(attrs.OrgDomain)
 	if err != nil {
@@ -209,6 +216,7 @@ func readConfig() (Attributes, error) {
 		FedAppID:            viper.GetString(AWSAcctFedAppIDFlag),
 		Format:              viper.GetString(FormatFlag),
 		LegacyAWSVariables:  viper.GetBool(LegacyAWSVariablesFlag),
+		ExpiryAWSVariables:  viper.GetBool(ExpiryAWSVariablesFlag),
 		OIDCAppID:           viper.GetString(OIDCClientIDFlag),
 		OpenBrowser:         viper.GetBool(OpenBrowserFlag),
 		OrgDomain:           viper.GetString(OrgDomainFlag),
@@ -295,6 +303,9 @@ func readConfig() (Attributes, error) {
 	}
 	if !attrs.LegacyAWSVariables {
 		attrs.LegacyAWSVariables = viper.GetBool(downCase(LegacyAWSVariablesEnvVar))
+	}
+	if !attrs.ExpiryAWSVariables {
+		attrs.ExpiryAWSVariables = viper.GetBool(downCase(ExpiryAWSVariablesEnvVar))
 	}
 	return attrs, nil
 }
@@ -467,6 +478,17 @@ func (c *Config) LegacyAWSVariables() bool {
 // SetLegacyAWSVariables --
 func (c *Config) SetLegacyAWSVariables(legacyAWSVariables bool) error {
 	c.legacyAWSVariables = legacyAWSVariables
+	return nil
+}
+
+// ExpiryAWSVariables --
+func (c *Config) ExpiryAWSVariables() bool {
+	return c.expiryAWSVariables
+}
+
+// SetExpiryAWSVariables --
+func (c *Config) SetExpiryAWSVariables(expiryAWSVariables bool) error {
+	c.expiryAWSVariables = expiryAWSVariables
 	return nil
 }
 

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -180,8 +180,9 @@ aws_access_key_id = %s
 aws_secret_access_key = %s
 aws_session_token = %s
 aws_security_token = %s
+x_security_token_expires = %s
 `
-		creds = fmt.Sprintf(creds, c.Profile(), ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken, ac.SessionToken)
+		creds = fmt.Sprintf(creds, c.Profile(), ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken, ac.SessionToken, ac.Expiration.Format(time.RFC3339))
 	} else {
 		creds = `
 [%s]

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
@@ -187,9 +188,11 @@ aws_security_token = %s
 aws_access_key_id = %s
 aws_secret_access_key = %s
 aws_session_token = %s
+x_security_token_expires = %s
 `
-		creds = fmt.Sprintf(creds, c.Profile(), ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken)
+		creds = fmt.Sprintf(creds, c.Profile(), ac.AccessKeyID, ac.SecretAccessKey, ac.SessionToken, ac.Expiration.Format(time.RFC3339))
 	}
+
 	_, err = f.WriteString(creds)
 	if err != nil {
 		return err

--- a/internal/output/aws_credentials_file_test.go
+++ b/internal/output/aws_credentials_file_test.go
@@ -58,7 +58,7 @@ func TestINIFormatCredentialsContent(t *testing.T) {
 		SecretAccessKey: "e",
 		SessionToken:    "f",
 	}
-	config, err := updateConfig(filename, "test", awsCreds, false)
+	config, err := updateConfig(filename, "test", awsCreds, false, false, "")
 	assert.NoError(t, err)
 
 	err = config.SaveTo(filename)
@@ -141,7 +141,7 @@ aws_security_token    = ghi
 		t.Run(test.name, func(t *testing.T) {
 			config, err := ini.Load(test.config)
 			require.NoError(t, err)
-			ini, err := updateINI(config, "default", test.legacy)
+			ini, err := updateINI(config, "default", test.legacy, false)
 			require.NoError(t, err)
 			section := ini.Section(test.section)
 			require.Equal(t, len(test.want), len(section.KeyStrings()))

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -317,6 +317,7 @@ func (s *SessionToken) fetchAWSCredentialWithSAMLRole(iar *idpAndRole, assertion
 		AccessKeyID:     *svcResp.Credentials.AccessKeyId,
 		SecretAccessKey: *svcResp.Credentials.SecretAccessKey,
 		SessionToken:    *svcResp.Credentials.SessionToken,
+		Expiration:      *svcResp.Credentials.Expiration,
 	}
 	return credential, nil
 }

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
@@ -284,7 +285,8 @@ func (s *SessionToken) renderCredential(ac *oaws.Credential) error {
 	var o output.Outputter
 	switch s.config.Format() {
 	case config.AWSCredentialsFormat:
-		o = output.NewAWSCredentialsFile(s.config.LegacyAWSVariables())
+		expiry := time.Now().Add(time.Duration(s.config.AWSSessionDuration()) * time.Second).Format(time.RFC3339)
+		o = output.NewAWSCredentialsFile(s.config.LegacyAWSVariables(), s.config.ExpiryAWSVariables(), expiry)
 	default:
 		o = output.NewEnvVar(s.config.LegacyAWSVariables())
 		fmt.Fprintf(os.Stderr, "\n")
@@ -317,7 +319,6 @@ func (s *SessionToken) fetchAWSCredentialWithSAMLRole(iar *idpAndRole, assertion
 		AccessKeyID:     *svcResp.Credentials.AccessKeyId,
 		SecretAccessKey: *svcResp.Credentials.SecretAccessKey,
 		SessionToken:    *svcResp.Credentials.SessionToken,
-		Expiration:      *svcResp.Credentials.Expiration,
 	}
 	return credential, nil
 }


### PR DESCRIPTION
Bringing in @tim-fitzgerald's work from #56. Writing
`x_security_token_expires` to AWS creds file is gated by a CLI flag
`--expiry-aws-variables`