### PR TITLE
--debug flag and release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 (July 13, 2023)
+
+* Print out operational debugging information flag [#113](https://github.com/okta/okta-aws-cli/pull/113), thanks [@monde](https://github.com/monde)!
+
 ## 1.0.2 (June 27, 2023)
 
 * [#112](https://github.com/okta/okta-aws-cli/pull/112), thanks [@monde](https://github.com/monde)!

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Also see the CLI's online help `$ okta-aws-cli --help`
 | (Over)write the given profile to the AWS credentials file (optional). WARNING: When enabled, overwriting can inadvertently remove dangling comments and extraneous formatting from the creds file. | `OKTA_AWSCLI_WRITE_AWS_CREDENTIALS=true` | `--write-aws-credentials` | `true` if flag is present  |
 | Emit deprecated AWS variable `aws_security_token` with duplicated value from `aws_session_token` | `OKTA_AWSCLI_LEGACY_AWS_VARIABLES=true` | `--legacy-aws-variables` | `true` if flag is present  |
 | Emit expiry timestamp `x_security_token_expires` in RFC3339 format for the session/security token (AWS credentials file only) | `OKTA_AWSCLI_EXPIRY_AWS_VARIABLES=true` | `--expiry-aws-variables` | `true` if flag is present  |
+| Print operational information to the screen for debugging purposes | `OKTA_AWSCLI_DEBUG=true` | `--debug` | `true` if flag is present  |
 | Verbosely print all API calls/responses to the screen | `OKTA_AWSCLI_DEBUG_API_CALLS=true` | `--debug-api-calls` | `true` if flag is present  |
 | HTTP/HTTPS Proxy support | `HTTP_PROXY` or `HTTPS_PROXY` | n/a | HTTP/HTTPS URL of proxy service (based on golang [net/http/httpproxy](https://pkg.go.dev/golang.org/x/net/http/httpproxy) package) |
 | Debug okta.yaml config file and exit | `OKTA_AWSCLI_DEBUG_CONFIG=true` | `--debug-config` | `true` if flag is present  |

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -158,6 +158,13 @@ func init() {
 			envVar: config.CacheAccessTokenEnvVar,
 		},
 		{
+			name:   config.DebugFlag,
+			short:  "g",
+			value:  false,
+			usage:  "Print operational information to the screen for debugging purposes",
+			envVar: config.DebugEnvVar,
+		},
+		{
 			name:   config.DebugAPICallsFlag,
 			short:  "d",
 			value:  false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// Version app version
-	Version = "1.0.2"
+	Version = "1.1.0"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"
@@ -46,6 +46,8 @@ const (
 	AWSIAMIdPFlag = "aws-iam-idp"
 	// AWSIAMRoleFlag cli flag const
 	AWSIAMRoleFlag = "aws-iam-role"
+	// DebugFlag cli flag const
+	DebugFlag = "debug"
 	// DebugAPICallsFlag cli flag const
 	DebugAPICallsFlag = "debug-api-calls"
 	// DebugConfigFlag cli flag const
@@ -97,6 +99,8 @@ const (
 	QRCodeEnvVar = "OKTA_AWSCLI_QR_CODE"
 	// WriteAWSCredentialsEnvVar env var const
 	WriteAWSCredentialsEnvVar = "OKTA_AWSCLI_WRITE_AWS_CREDENTIALS"
+	// DebugEnvVar env var const
+	DebugEnvVar = "OKTA_AWSCLI_DEBUG"
 	// DebugAPICallsEnvVar env var const
 	DebugAPICallsEnvVar = "OKTA_AWSCLI_DEBUG_API_CALLS"
 	// DebugConfigEnvVar env var const
@@ -133,6 +137,7 @@ type Config struct {
 	awsCredentials      string
 	writeAWSCredentials bool
 	openBrowser         bool
+	debug               bool
 	debugAPICalls       bool
 	debugConfig         bool
 	legacyAWSVariables  bool
@@ -162,6 +167,7 @@ type Attributes struct {
 	AWSCredentials      string
 	WriteAWSCredentials bool
 	OpenBrowser         bool
+	Debug               bool
 	DebugAPICalls       bool
 	DebugConfig         bool
 	LegacyAWSVariables  bool
@@ -194,6 +200,7 @@ func NewConfig(attrs Attributes) (*Config, error) {
 		awsCredentials:      attrs.AWSCredentials,
 		writeAWSCredentials: attrs.WriteAWSCredentials,
 		openBrowser:         attrs.OpenBrowser,
+		debug:               attrs.Debug,
 		debugAPICalls:       attrs.DebugAPICalls,
 		debugConfig:         attrs.DebugConfig,
 		legacyAWSVariables:  attrs.LegacyAWSVariables,
@@ -232,6 +239,7 @@ func readConfig() (Attributes, error) {
 		AWSIAMIdP:           viper.GetString(AWSIAMIdPFlag),
 		AWSIAMRole:          viper.GetString(AWSIAMRoleFlag),
 		AWSSessionDuration:  viper.GetInt64(SessionDurationFlag),
+		Debug:               viper.GetBool(DebugFlag),
 		DebugAPICalls:       viper.GetBool(DebugAPICallsFlag),
 		DebugConfig:         viper.GetBool(DebugConfigFlag),
 		FedAppID:            viper.GetString(AWSAcctFedAppIDFlag),
@@ -324,6 +332,9 @@ func readConfig() (Attributes, error) {
 	}
 	if !attrs.OpenBrowser {
 		attrs.OpenBrowser = viper.GetBool(downCase(OpenBrowserEnvVar))
+	}
+	if !attrs.Debug {
+		attrs.Debug = viper.GetBool(downCase(DebugEnvVar))
 	}
 	if !attrs.DebugAPICalls {
 		attrs.DebugAPICalls = viper.GetBool(downCase(DebugAPICallsEnvVar))
@@ -483,6 +494,17 @@ func (c *Config) OpenBrowser() bool {
 // SetOpenBrowser --
 func (c *Config) SetOpenBrowser(openBrowser bool) error {
 	c.openBrowser = openBrowser
+	return nil
+}
+
+// Debug --
+func (c *Config) Debug() bool {
+	return c.debug
+}
+
+// SetDebug --
+func (c *Config) SetDebug(debug bool) error {
+	c.debug = debug
 	return nil
 }
 

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -249,7 +249,17 @@ func (s *SessionToken) selectFedApp(apps []*oktaApplication) (string, error) {
 			choice = fmt.Sprintf(choiceArnPrintFmt, choice, app.Settings.App.IdentityProviderARN)
 			if oktaConfig != nil && len(oktaConfig.AWSCLI.IDPS) > 0 {
 				if label, ok := oktaConfig.AWSCLI.IDPS[app.Settings.App.IdentityProviderARN]; ok {
+					if s.config.Debug() {
+						fmt.Fprintf(os.Stderr, "  found IdP ARN %q having friendly label %q\n", app.Settings.App.IdentityProviderARN, label)
+					}
 					choice = label
+				} else if s.config.Debug() {
+					fmt.Fprintf(os.Stderr, "  did not find friendly label for IdP ARN\n")
+					fmt.Fprintf(os.Stderr, "    %q\n", app.Settings.App.IdentityProviderARN)
+					fmt.Fprintf(os.Stderr, "    in okta.yaml awscli.idps map:\n")
+					for arn, label := range oktaConfig.AWSCLI.IDPS {
+						fmt.Fprintf(os.Stderr, "      %q: %q\n", arn, label)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## 1.1.0 (July 13, 2023)

* Print out operational debugging information flag [#113](https://github.com/okta/okta-aws-cli/pull/113), thanks [@monde](https://github.com/monde)!
