### PR TITLE
Refine friendly IdP and Role label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1 (August 15, 2023)
+
+* Friendly IdP and Role labels don't also print out ARN value (less text clutter in the UI)
+
 ## 1.2.0 (August 15, 2023)
 
 * [Friendly Role menu labels](https://github.com/okta/okta-aws-cli#friendly-idp-and-role-menu-labels) for long ARN values can be set in `$HOME/.okta/okta.yaml`

--- a/README.md
+++ b/README.md
@@ -314,14 +314,14 @@ that practice with read-only friendly okta-aws-cli application values.
 
 ```
 ? Choose an IdP:  [Use arrows to move, type to filter]
-> Fed App 1 Label (arn:aws:iam::123456789012:saml-provider/company-okta-idp)
-  Fed App 2 Label (arn:aws:iam::012345678901:saml-provider/company-okta-idp)
-  Fed App 3 Label (arn:aws:iam::901234567890:saml-provider/company-okta-idp)
-  Fed App 4 Label (arn:aws:iam::890123456789:saml-provider/company-okta-idp)
+> Fed App 1 Label
+  Fed App 2 Label
+  Fed App 3 Label
+  Fed App 4 Label
 
 ? Choose a Role:  [Use arrows to move, type to filter]
 > Admin (arn:aws:iam::123456789012:role/admin)
-  Op (arn:aws:iam::123456789012:role/operator)
+  Ops
 ```
 
 #### Example `$HOME/.okta/okta.yaml`
@@ -351,8 +351,8 @@ awscli:
   Marketing Development
 
 ? Choose a Role:  [Use arrows to move, type to filter]
-> Prod Admin (arn:aws:iam::123456789012:role/admin)
-  Prod Ops (arn:aws:iam::123456789012:role/operator)
+> Prod Admin
+  Prod Ops
 ```
 
 #### Debug okta.yaml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// Version app version
-	Version = "1.2.0"
+	Version = "1.2.1"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"

--- a/internal/sessiontoken/sessiontoken.go
+++ b/internal/sessiontoken/sessiontoken.go
@@ -73,8 +73,6 @@ const (
 	roleSelectedTemplate     = `  {{color "default+hb"}}Role: {{color "reset"}}{{color "cyan"}}{{ .Role }}{{color "reset"}}`
 	dotOktaDir               = ".okta"
 	tokenFileName            = "awscli-access-token.json"
-
-	choiceArnPrintFmt = "%s (%s)"
 )
 
 type idpTemplateData struct {
@@ -234,7 +232,7 @@ func (s *SessionToken) choiceFriendlyLabelIDP(alternative string, oktaConfig *co
 		if s.config.Debug() {
 			fmt.Fprintf(os.Stderr, "  found IdP ARN %q having friendly label %q\n", arn, label)
 		}
-		return fmt.Sprintf(choiceArnPrintFmt, label, arn)
+		return label
 	} else if s.config.Debug() {
 		fmt.Fprintf(os.Stderr, "  did not find friendly label for IdP ARN\n")
 		fmt.Fprintf(os.Stderr, "    %q\n", arn)
@@ -253,8 +251,7 @@ func (s *SessionToken) selectFedApp(apps []*oktaApplication) (string, error) {
 	oktaConfig, _ := s.config.OktaConfig()
 
 	for i, app := range apps {
-		defaultLabel := fmt.Sprintf(choiceArnPrintFmt, app.Label, app.Settings.App.IdentityProviderARN)
-		choiceLabel := s.choiceFriendlyLabelIDP(defaultLabel, oktaConfig, app.Settings.App.IdentityProviderARN)
+		choiceLabel := s.choiceFriendlyLabelIDP(app.Label, oktaConfig, app.Settings.App.IdentityProviderARN)
 
 		// when OKTA_AWSCLI_IAM_IDP / --aws-iam-idp is set
 		if s.config.AWSIAMIdP() == app.Settings.App.IdentityProviderARN {
@@ -378,7 +375,7 @@ func (s *SessionToken) choiceFriendlyLabelRole(arn string, oktaConfig *config.Ok
 		if s.config.Debug() {
 			fmt.Fprintf(os.Stderr, "  found Role ARN %q having friendly label %q\n", arn, label)
 		}
-		return fmt.Sprintf(choiceArnPrintFmt, label, arn)
+		return label
 	} else if s.config.Debug() {
 		fmt.Fprintf(os.Stderr, "  did not find friendly label for Role ARN\n")
 		fmt.Fprintf(os.Stderr, "    %q\n", arn)


### PR DESCRIPTION
Friendly IdP and Role labels don't also print out ARN value (less text clutter in the UI)

Example:
```
$ otka-aws-cli
System web browser will open the following URL to begin Okta device authorization for the AWS CLI

https://example.okta.com/activate?user_code=ZJVFJZNT

? Choose an IdP:  [Use arrows to move, type to filter]
> S3 IdP
  EC2 IdP
  EKS IdP
  CloudFront IdP
```