### PR TITLE
preparing 1.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.2 (August 30, 2023)
+
+* Ensure evaluation of CLI flag for profile is in the same order as the other flags [#124](https://github.com/okta/okta-aws-cli/pull/124)
+* Retry cached access token if it isn't expired by but receives API error [#127](https://github.com/okta/okta-aws-cli/pull/127)
+
 ## 1.2.1 (August 15, 2023)
 
 * Friendly IdP and Role labels don't also print out ARN value (less text clutter in the UI)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// Version app version
-	Version = "1.2.1"
+	Version = "1.2.2"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"


### PR DESCRIPTION
## 1.2.2 (August 30, 2023)

* Ensure evaluation of CLI flag for profile is in the same order as the other flags [#124](https://github.com/okta/okta-aws-cli/pull/124)
* Retry cached access token if it isn't expired by but receives API error [#127](https://github.com/okta/okta-aws-cli/pull/127)