### PR TITLE
`--exec` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,14 +32,14 @@ Emits IAM temporary credentials as JSON in [process
 credentials](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html)
 format.
 
-### (expected) Secondary command exec
+### (Complete) Execute follow-on command
 
 Instead of scripting and/or eval'ing `okta-aws-cli` into a shell and then
 running another command have `okta-aws-cli` run the command directly passing
 along the IAM credentials as environment variables.
 
 ```
-# CLI exec's anything after the double dash "--" as another command.
+# CLI exec's anything after the double dash "--" arguments terminator as another command.
 $ okta-aws-cli web \
     --org-domain test.okta.com \
     --oidc-client-id 0oa5wyqjk6Wm148fE1d7 \
@@ -69,6 +69,16 @@ $ okta-aws-cli web \
     --oidc-client-id 0oa5wyqjk6Wm148fE1d7 \
     --open-browser \
     --open-browser-command "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --profile-directory='Profile 1'"
+```
+
+## 2.0.0-beta.2 (October 5, 2023)
+
+Execute a subcommand directly from `okta-aws-cli`
+
+```
+$ okta-aws-cli m2m --format noop --exec -- aws s3 ls s3://example
+                           PRE aaa/
+2023-03-08 16:01:01          4 a.log
 ```
 
 ## 2.0.0-beta.1 (October 2, 2023)

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -134,6 +134,13 @@ func init() {
 			Usage:  "Verbosely print all API calls/responses to the screen",
 			EnvVar: config.DebugAPICallsEnvVar,
 		},
+		{
+			Name:   config.ExecFlag,
+			Short:  "j",
+			Value:  false,
+			Usage:  "Execute any shell commands after the '--' CLI arguments termination",
+			EnvVar: config.ExecEnvVar,
+		},
 	}
 
 	rootCmd = NewRootCommand()

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -23,16 +23,21 @@ import (
 
 // Credential Convenience representation of an AWS credential.
 type Credential struct {
-	AccessKeyID     string     `ini:"aws_access_key_id"     json:"AccessKeyId,omitempty"`
-	SecretAccessKey string     `ini:"aws_secret_access_key" json:"SecretAccessKey,omitempty"`
-	SessionToken    string     `ini:"aws_session_token"     json:"SessionToken,omitempty"`
-	Version         int        `ini:"aws_version"           json:"Version,omitempty"`
-	Expiration      *time.Time `ini:"aws_expiration"        json:"Expiration,omitempty"`
+	AccessKeyID     string `ini:"aws_access_key_id"     json:"AccessKeyId,omitempty"`
+	SecretAccessKey string `ini:"aws_secret_access_key" json:"SecretAccessKey,omitempty"`
+	SessionToken    string `ini:"aws_session_token"     json:"SessionToken,omitempty"`
+}
+
+// ProcessCredential Convenience representation of an AWS credential used for process credential format.
+type ProcessCredential struct {
+	Credential
+	Version    int        `json:"Version,omitempty"`
+	Expiration *time.Time `json:"Expiration,omitempty"`
 }
 
 // MarshalJSON ensure Expiration date time is formatted RFC 3339 format.
-func (c *Credential) MarshalJSON() ([]byte, error) {
-	type Alias Credential
+func (c *ProcessCredential) MarshalJSON() ([]byte, error) {
+	type Alias ProcessCredential
 	var exp string
 	if c.Expiration != nil {
 		exp = c.Expiration.Format(time.RFC3339)

--- a/internal/aws/aws_test.go
+++ b/internal/aws/aws_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestCredentialJSON(t *testing.T) {
 	hbtGo := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	c := Credential{
+	c := ProcessCredential{
 		Expiration: &hbtGo,
 	}
 	credStr, err := json.Marshal(c)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,8 @@ const (
 	EnvVarFormat = "env-var"
 	// ProcessCredentialsFormat format const
 	ProcessCredentialsFormat = "process-credentials"
+	// NoopFormat format const
+	NoopFormat = "noop"
 
 	// AuthzIDFlag cli flag const
 	AuthzIDFlag = "authz-id"
@@ -64,6 +66,8 @@ const (
 	DebugFlag = "debug"
 	// DebugAPICallsFlag cli flag const
 	DebugAPICallsFlag = "debug-api-calls"
+	// ExecFlag cli flag const
+	ExecFlag = "exec"
 	// FormatFlag cli flag const
 	FormatFlag = "format"
 	// OIDCClientIDFlag cli flag const
@@ -111,6 +115,8 @@ const (
 	DebugAPICallsEnvVar = "OKTA_AWSCLI_DEBUG_API_CALLS"
 	// ExpiryAWSVariablesEnvVar env var const
 	ExpiryAWSVariablesEnvVar = "OKTA_AWSCLI_EXPIRY_AWS_VARIABLES"
+	// ExecEnvVar env var const
+	ExecEnvVar = "OKTA_AWSCLI_EXEC"
 	// FormatEnvVar env var const
 	FormatEnvVar = "OKTA_AWSCLI_FORMAT"
 	// LegacyAWSVariablesEnvVar env var const
@@ -174,6 +180,7 @@ type Config struct {
 	customScope         string
 	debug               bool
 	debugAPICalls       bool
+	exec                bool
 	expiryAWSVariables  bool
 	fedAppID            string
 	format              string
@@ -201,6 +208,7 @@ type Attributes struct {
 	CustomScope         string
 	Debug               bool
 	DebugAPICalls       bool
+	Exec                bool
 	ExpiryAWSVariables  bool
 	FedAppID            string
 	Format              string
@@ -240,6 +248,7 @@ func NewConfig(attrs *Attributes) (*Config, error) {
 		debug:               attrs.Debug,
 		debugAPICalls:       attrs.DebugAPICalls,
 		expiryAWSVariables:  attrs.ExpiryAWSVariables,
+		exec:                attrs.Exec,
 		fedAppID:            attrs.FedAppID,
 		format:              attrs.Format,
 		legacyAWSVariables:  attrs.LegacyAWSVariables,
@@ -284,6 +293,7 @@ func readConfig() (Attributes, error) {
 		CustomScope:         viper.GetString(CustomScopeFlag),
 		Debug:               viper.GetBool(DebugFlag),
 		DebugAPICalls:       viper.GetBool(DebugAPICallsFlag),
+		Exec:                viper.GetBool(ExecFlag),
 		FedAppID:            viper.GetString(AWSAcctFedAppIDFlag),
 		Format:              viper.GetString(FormatFlag),
 		LegacyAWSVariables:  viper.GetBool(LegacyAWSVariablesFlag),
@@ -406,6 +416,9 @@ func readConfig() (Attributes, error) {
 	}
 	if !attrs.CacheAccessToken {
 		attrs.CacheAccessToken = viper.GetBool(downCase(CacheAccessTokenEnvVar))
+	}
+	if !attrs.Exec {
+		attrs.Exec = viper.GetBool(downCase(ExecEnvVar))
 	}
 	return attrs, nil
 }
@@ -532,6 +545,17 @@ func (c *Config) DebugAPICalls() bool {
 // SetDebugAPICalls --
 func (c *Config) SetDebugAPICalls(debugAPICalls bool) error {
 	c.debugAPICalls = debugAPICalls
+	return nil
+}
+
+// Exec --
+func (c *Config) Exec() bool {
+	return c.exec
+}
+
+// SetExec --
+func (c *Config) SetExec(exec bool) error {
+	c.exec = exec
 	return nil
 }
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package exec
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"strings"
+
+	oaws "github.com/okta/okta-aws-cli/internal/aws"
+)
+
+// Exec is a executor / a process runner
+type Exec struct {
+	name string
+	args []string
+}
+
+// NewExec Create a new executor
+func NewExec() (*Exec, error) {
+	args := []string{}
+	foundArgs := false
+	for _, arg := range os.Args {
+		if arg == "--" {
+			foundArgs = true
+			continue
+		}
+		if !foundArgs {
+			continue
+		}
+
+		args = append(args, arg)
+	}
+
+	if len(args) < 1 {
+		return nil, fmt.Errorf("there must be at least one additional argument after the '--' CLI argument terminator")
+	}
+
+	name := args[0]
+	args = args[1:]
+	ex := &Exec{
+		name: name,
+		args: args,
+	}
+
+	return ex, nil
+}
+
+// Run Run the executor
+func (e *Exec) Run(oc *oaws.Credential) error {
+	pairs := map[string]string{}
+	// pre-populate pairs with any existing env var starting with "AWS_"
+	for _, kv := range os.Environ() {
+		pair := strings.SplitN(kv, "=", 2)
+		k := pair[0]
+		if strings.HasPrefix(k, "AWS_") {
+			pairs[k] = pair[1]
+		}
+	}
+	// add creds env var names to pairs
+	pairs["AWS_ACCESS_KEY_ID"] = oc.AccessKeyID
+	pairs["AWS_SECRET_ACCESS_KEY"] = oc.SecretAccessKey
+	pairs["AWS_SESSION_TOKEN"] = oc.SessionToken
+
+	cmd := osexec.Command(e.name, e.args...)
+	for k, v := range pairs {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	out, err := cmd.Output()
+	if ee, ok := err.(*osexec.ExitError); ok {
+		fmt.Fprintf(os.Stderr, "error running process\n")
+		fmt.Fprintf(os.Stderr, "%s %s\n", e.name, strings.Join(e.args, " "))
+		fmt.Fprintf(os.Stderr, "%s\n", ee.Stderr)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", string(out))
+	return nil
+}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
+	"github.com/okta/okta-aws-cli/internal/utils"
 )
 
 // Exec is a executor / a process runner
@@ -86,7 +87,7 @@ func (e *Exec) Run(oc *oaws.Credential) error {
 	if ee, ok := err.(*osexec.ExitError); ok {
 		fmt.Fprintf(os.Stderr, "error running process\n")
 		fmt.Fprintf(os.Stderr, "%s %s\n", e.name, strings.Join(e.args, " "))
-		fmt.Fprintf(os.Stderr, "%s\n", ee.Stderr)
+		fmt.Fprintf(os.Stderr, utils.PassThroughStringNewLineFMT, ee.Stderr)
 	}
 	if err != nil {
 		return err

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	dynamicstruct "github.com/ompluscator/dynamic-struct"
 	"github.com/pkg/errors"
 	"gopkg.in/ini.v1"
@@ -178,7 +179,7 @@ func NewAWSCredentialsFile(legacyVars bool, expiryVars bool, expiry string) *AWS
 
 // Output Satisfies the Outputter interface and appends AWS credentials to
 // credentials file.
-func (e *AWSCredentialsFile) Output(c *config.Config, oc *oaws.Credential) error {
+func (e *AWSCredentialsFile) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
 	if c.WriteAWSCredentials() {
 		return e.writeConfig(c, oc)
 	}

--- a/internal/output/envvar.go
+++ b/internal/output/envvar.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/okta/okta-aws-cli/internal/aws"
+	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
 
@@ -38,20 +38,20 @@ func NewEnvVar(legacyVars bool) *EnvVar {
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as shell
 // export statements to STDOUT
-func (e *EnvVar) Output(c *config.Config, ac *aws.Credential) error {
+func (e *EnvVar) Output(c *config.Config, oc *oaws.Credential) error {
 	if runtime.GOOS == "windows" {
-		fmt.Printf("setx AWS_ACCESS_KEY_ID %s\n", ac.AccessKeyID)
-		fmt.Printf("setx AWS_SECRET_ACCESS_KEY %s\n", ac.SecretAccessKey)
-		fmt.Printf("setx AWS_SESSION_TOKEN %s\n", ac.SessionToken)
+		fmt.Printf("setx AWS_ACCESS_KEY_ID %s\n", oc.AccessKeyID)
+		fmt.Printf("setx AWS_SECRET_ACCESS_KEY %s\n", oc.SecretAccessKey)
+		fmt.Printf("setx AWS_SESSION_TOKEN %s\n", oc.SessionToken)
 		if e.LegacyAWSVariables {
-			fmt.Printf("setx AWS_SECURITY_TOKEN %s\n", ac.SessionToken)
+			fmt.Printf("setx AWS_SECURITY_TOKEN %s\n", oc.SessionToken)
 		}
 	} else {
-		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", ac.AccessKeyID)
-		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", ac.SecretAccessKey)
-		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", ac.SessionToken)
+		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", oc.AccessKeyID)
+		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", oc.SecretAccessKey)
+		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", oc.SessionToken)
 		if e.LegacyAWSVariables {
-			fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", ac.SessionToken)
+			fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", oc.SessionToken)
 		}
 	}
 

--- a/internal/output/envvar.go
+++ b/internal/output/envvar.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
@@ -38,7 +39,7 @@ func NewEnvVar(legacyVars bool) *EnvVar {
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as shell
 // export statements to STDOUT
-func (e *EnvVar) Output(c *config.Config, oc *oaws.Credential) error {
+func (e *EnvVar) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
 	if runtime.GOOS == "windows" {
 		fmt.Printf("setx AWS_ACCESS_KEY_ID %s\n", oc.AccessKeyID)
 		fmt.Printf("setx AWS_SECRET_ACCESS_KEY %s\n", oc.SecretAccessKey)

--- a/internal/output/noop.go
+++ b/internal/output/noop.go
@@ -1,0 +1,36 @@
+/*
+	* Copyright (c) 2023-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package output
+
+import (
+	oaws "github.com/okta/okta-aws-cli/internal/aws"
+	"github.com/okta/okta-aws-cli/internal/config"
+)
+
+// NoopCredentials Don't output credentials
+type NoopCredentials struct{}
+
+// NewNoopCredentials Creates a new NoopCredentials
+func NewNoopCredentials() *NoopCredentials {
+	return &NoopCredentials{}
+}
+
+// Output Satisfies the Outputter interface and outputs nothing
+func (n *NoopCredentials) Output(c *config.Config, oc *oaws.Credential) error {
+	// no-op
+	return nil
+}

--- a/internal/output/noop.go
+++ b/internal/output/noop.go
@@ -17,6 +17,7 @@
 package output
 
 import (
+	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
@@ -30,7 +31,7 @@ func NewNoopCredentials() *NoopCredentials {
 }
 
 // Output Satisfies the Outputter interface and outputs nothing
-func (n *NoopCredentials) Output(c *config.Config, oc *oaws.Credential) error {
+func (n *NoopCredentials) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
 	// no-op
 	return nil
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -21,17 +21,18 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
 
 // Outputter Interface to output AWS credentials in different formats.
 type Outputter interface {
-	Output(c *config.Config, oc *oaws.Credential) error
+	Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error
 }
 
 // RenderAWSCredential Renders the credentials in the prescribed format.
-func RenderAWSCredential(cfg *config.Config, oc *oaws.Credential) error {
+func RenderAWSCredential(cfg *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
 	var o Outputter
 	switch cfg.Format() {
 	case config.AWSCredentialsFormat:
@@ -46,5 +47,5 @@ func RenderAWSCredential(cfg *config.Config, oc *oaws.Credential) error {
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 
-	return o.Output(cfg, oc)
+	return o.Output(cfg, oc, ac)
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -21,17 +21,17 @@ import (
 	"os"
 	"time"
 
-	"github.com/okta/okta-aws-cli/internal/aws"
+	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
 
 // Outputter Interface to output AWS credentials in different formats.
 type Outputter interface {
-	Output(c *config.Config, ac *aws.Credential) error
+	Output(c *config.Config, oc *oaws.Credential) error
 }
 
 // RenderAWSCredential Renders the credentials in the prescribed format.
-func RenderAWSCredential(cfg *config.Config, ac *aws.Credential) error {
+func RenderAWSCredential(cfg *config.Config, oc *oaws.Credential) error {
 	var o Outputter
 	switch cfg.Format() {
 	case config.AWSCredentialsFormat:
@@ -39,10 +39,12 @@ func RenderAWSCredential(cfg *config.Config, ac *aws.Credential) error {
 		o = NewAWSCredentialsFile(cfg.LegacyAWSVariables(), cfg.ExpiryAWSVariables(), expiry)
 	case config.ProcessCredentialsFormat:
 		o = NewProcessCredentials()
+	case config.NoopFormat:
+		o = NewNoopCredentials()
 	default:
 		o = NewEnvVar(cfg.LegacyAWSVariables())
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 
-	return o.Output(cfg, ac)
+	return o.Output(cfg, oc)
 }

--- a/internal/output/process_credentials.go
+++ b/internal/output/process_credentials.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
@@ -35,12 +36,16 @@ func NewProcessCredentials() *ProcessCredentials {
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as JSON
 // to STDOUT
-func (p *ProcessCredentials) Output(c *config.Config, oc *oaws.Credential) error {
+func (p *ProcessCredentials) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
 	// See AWS docs: "Note As of this writing, the Version key must be set to 1.
 	// This might increment over time as the structure evolves."
-	oc.Version = 1
+	poc := &oaws.ProcessCredential{
+		Credential: *oc,
+		Expiration: ac.Expiration,
+		Version:    1,
+	}
 
-	credJSON, err := json.MarshalIndent(oc, "", "  ")
+	credJSON, err := json.MarshalIndent(poc, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/output/process_credentials.go
+++ b/internal/output/process_credentials.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/okta/okta-aws-cli/internal/aws"
+	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
 
@@ -35,12 +35,12 @@ func NewProcessCredentials() *ProcessCredentials {
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as JSON
 // to STDOUT
-func (p *ProcessCredentials) Output(c *config.Config, ac *aws.Credential) error {
+func (p *ProcessCredentials) Output(c *config.Config, oc *oaws.Credential) error {
 	// See AWS docs: "Note As of this writing, the Version key must be set to 1.
 	// This might increment over time as the structure evolves."
-	ac.Version = 1
+	oc.Version = 1
 
-	credJSON, err := json.MarshalIndent(ac, "", "  ")
+	credJSON, err := json.MarshalIndent(oc, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/output/process_credentials_test.go
+++ b/internal/output/process_credentials_test.go
@@ -34,7 +34,7 @@ func TestProcessCredentials(t *testing.T) {
 	"SessionToken": "the AWS session token for temporary credentials", 
 	"Expiration": "2009-11-10T23:00:00Z"
 }`
-	result := aws.Credential{}
+	result := aws.ProcessCredential{}
 	err := json.Unmarshal([]byte(credsJSON), &result)
 	require.NoError(t, err)
 	require.Equal(t, "an AWS access key", result.AccessKeyID)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -31,4 +31,6 @@ const (
 	XOktaAWSCLIWebOperation = "web"
 	// XOktaAWSCLIM2MOperation m2m op value for the x okta aws cli header
 	XOktaAWSCLIM2MOperation = "m2m"
+	// PassThroughStringNewLineFMT string formatter to make lint happy
+	PassThroughStringNewLineFMT = "%s\n"
 )

--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -46,6 +46,7 @@ import (
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	boff "github.com/okta/okta-aws-cli/internal/backoff"
 	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/okta/okta-aws-cli/internal/exec"
 	"github.com/okta/okta-aws-cli/internal/okta"
 	"github.com/okta/okta-aws-cli/internal/output"
 	"github.com/okta/okta-aws-cli/internal/utils"
@@ -124,6 +125,14 @@ func NewWebSSOAuthentication(cfg *config.Config) (token *WebSSOAuthentication, e
 			return nil, fmt.Errorf("arguments --%s , --%s , and --%s must be set for %q format", config.AWSIAMIdPFlag, config.AWSIAMRoleFlag, config.OpenBrowserFlag, cfg.Format())
 		}
 	}
+
+	// Check if exec arg is present and that there are args for it before doing any work
+	if cfg.Exec() {
+		if _, err := exec.NewExec(); err != nil {
+			return nil, err
+		}
+	}
+
 	return token, nil
 }
 
@@ -294,14 +303,21 @@ func (w *WebSSOAuthentication) establishTokenWithFedAppID(clientID, fedAppID str
 		return err
 	}
 
-	cred, err := w.awsAssumeRoleWithSAML(iar, assertion)
+	oc, err := w.awsAssumeRoleWithSAML(iar, assertion)
 	if err != nil {
 		return err
 	}
 
-	err = output.RenderAWSCredential(w.config, cred)
+	err = output.RenderAWSCredential(w.config, oc)
 	if err != nil {
 		return err
+	}
+
+	if w.config.Exec() {
+		exe, _ := exec.NewExec()
+		if err := exe.Run(oc); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -309,11 +325,11 @@ func (w *WebSSOAuthentication) establishTokenWithFedAppID(clientID, fedAppID str
 
 // awsAssumeRoleWithSAML Get AWS Credentials with an STS Assume Role With SAML AWS
 // API call.
-func (w *WebSSOAuthentication) awsAssumeRoleWithSAML(iar *idpAndRole, assertion string) (credential *oaws.Credential, err error) {
+func (w *WebSSOAuthentication) awsAssumeRoleWithSAML(iar *idpAndRole, assertion string) (oc *oaws.Credential, err error) {
 	awsCfg := aws.NewConfig().WithHTTPClient(w.config.HTTPClient())
 	sess, err := session.NewSession(awsCfg)
 	if err != nil {
-		return nil, err
+		return
 	}
 	svc := sts.New(sess)
 	input := &sts.AssumeRoleWithSAMLInput{
@@ -324,16 +340,16 @@ func (w *WebSSOAuthentication) awsAssumeRoleWithSAML(iar *idpAndRole, assertion 
 	}
 	svcResp, err := svc.AssumeRoleWithSAML(input)
 	if err != nil {
-		return nil, err
+		return
 	}
 
-	credential = &oaws.Credential{
+	oc = &oaws.Credential{
 		AccessKeyID:     *svcResp.Credentials.AccessKeyId,
 		SecretAccessKey: *svcResp.Credentials.SecretAccessKey,
 		SessionToken:    *svcResp.Credentials.SessionToken,
 		Expiration:      svcResp.Credentials.Expiration,
 	}
-	return credential, nil
+	return oc, nil
 }
 
 // choiceFriendlyLabelRole returns a friendly choice for pretty printing Role


### PR DESCRIPTION
Add `--exec` subcommand to avoid writing credentials to disk or injectinginto the shell

Closes #135

Example 1

```
$ okta-aws-cli m2m --format noop --exec -- printenv
AWS_REGION=us-east-1
AWS_ACCESS_KEY_ID=ASIAUJHVCS6UYRTRTSQE
AWS_SECRET_ACCESS_KEY=TmvLOM/doSWfmIMK...
AWS_SESSION_TOKEN=FwoGZXIvYXdzEF8aDKrf...
```

Example 2

```
$ okta-aws-cli m2m --format noop --exec -- aws s3 ls s3://example
                           PRE aaa/
2023-03-08 16:01:01          4 a.log
```

Example 3 (process had error and also writes to STDERR)

```
$ okta-aws-cli m2m --format noop --exec -- aws s3 mb s3://no-access-example
error running process
aws s3 mb s3://yz-nomad-og
make_bucket failed: s3://no-access-example An error occurred (AccessDenied) when calling the CreateBucket operation: Access Denied

Error: exit status 1
```