### PR TITLE
web command - collect all roles for an AWS Fed App (idp) at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,29 @@ $ okta-aws-cli web \
     --exec -- aws ec2 describe-instances
 ```
 
+### (Complete) Collect all roles for an AWS Fed App (IdP) at once
+
+`okta-aws-cli web` will collect all available AWS IAM Roles for a given Okta AWS
+Federation app (IdP) at once.  This is a feature specific to writing the
+`$HOME/.aws/credentials` file. Roles will be AWS account alias name (if STS list
+aliases is available on the given role) then `-` then abbreviated role name.
+
+
+```
+# AWS account alias "myorg", given IdP associated with "AWS Account Federation"
+# and an app associated with two roles.
+
+$ okta-aws-cli web \
+    --org-domain test.okta.com \
+    --oidc-client-id 0oa5wyqjk6Wm148fE1d7 \
+    --write-aws-credentials \
+    --all-profiles
+
+? Choose an IdP: AWS Account Federation
+Updated profile "myorg-S3-read" in credentials file "/Users/me/.aws/credentials".
+Updated profile "myorg-S3-write" in credentials file "/Users/me/.aws/credentials".
+```
+
 ### (expected) Alternate web browser open command
 
 The `web` command will open the system's default web browser when the
@@ -70,6 +93,11 @@ $ okta-aws-cli web \
     --open-browser \
     --open-browser-command "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --profile-directory='Profile 1'"
 ```
+
+## 2.0.0-beta.3 (October 10, 2023)
+
+`okta-aws-cli web` can collect all roles to an AWS credentials file for a given
+AWS Federation App (IdP) in one invocation of the CLI.
 
 ## 2.0.0-beta.2 (October 5, 2023)
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ documentation](#configuration).*
 
 `okta-aws-cli` is a CLI program allowing Okta to act as an identity provider and
 retrieve AWS IAM temporary credentials for use in AWS CLI, AWS SDKs, and other
-tools accessing the AWS API. There are two primary commands of operation: `web` -
-combined human and device authorization; and `m2m` - headless authorization.
+tools accessing the AWS API. There are two primary commands of operation: `web`
+- combined human and device authorization; and `m2m` - headless authorization.
 `okta-aws-cli web` is native to the Okta Identity Engine and its authentication
 and device authorization flows. `okta-aws-cli web` is not compatible with Okta
-Classic orgs. `okta-aws-cli m2m` makes use of public/private authorization and
-OIDC. 
+Classic orgs. `okta-aws-cli m2m` makes use of private key  (OAuth2)
+authorization and OIDC. 
 
 Example `okta-aws-cli` `web` command with environment variables (when command is
 missing *defaults* to `web`) output:
@@ -390,6 +390,7 @@ These settings are all optional:
 | AWS IAM Identity Provider ARN | Preselects the IdP list to this preferred IAM Identity Provider. If there are other IdPs available they will not be listed. | `--aws-iam-idp [value]` | `OKTA_AWSCLI_IAM_IDP` |
 | Display QR Code | `true` if flag is present | `--qr-code` | `OKTA_AWSCLI_QR_CODE=true` |
 | Automatically open the activation URL with the system web browser | `true` if flag is present | `--open-browser` | `OKTA_AWSCLI_OPEN_BROWSER=true` |
+| Gather all profiles for a given IdP (implies aws-credentials file output format)) | `true` if flag is present | `--all-profiles` | `OKTA_AWSCLI_OPEN_BROWSER=true` |
 
 #### Allowed Web SSO Client ID
 
@@ -734,6 +735,28 @@ aws s3 mb s3://yz-nomad-og
 make_bucket failed: s3://no-access-example An error occurred (AccessDenied) when calling the CreateBucket operation: Access Denied
 
 Error: exit status 1
+```
+
+### Collect all roles for an AWS Fed App (IdP) at once
+
+`okta-aws-cli web` will collect all available AWS IAM Roles for a given Okta AWS
+Federation app (IdP) at once.  This is a feature specific to writing the
+`$HOME/.aws/credentials` file. Roles will be AWS account alias name (if STS list
+aliases is available on the given role) then `-` then abbreviated role name.
+
+```
+# AWS account alias "myorg", given IdP associated with "AWS Account Federation"
+# and an app associated with two roles.
+
+$ okta-aws-cli web \
+    --org-domain test.okta.com \
+    --oidc-client-id 0oa5wyqjk6Wm148fE1d7 \
+    --write-aws-credentials \
+    --all-profiles
+
+? Choose an IdP: AWS Account Federation
+Updated profile "myorg-S3-read" in credentials file "/Users/me/.aws/credentials".
+Updated profile "myorg-S3-write" in credentials file "/Users/me/.aws/credentials".
 ```
 
 ### Help

--- a/cmd/root/web/web.go
+++ b/cmd/root/web/web.go
@@ -54,6 +54,13 @@ var (
 			Usage:  "Automatically open the activation URL with the system web browser",
 			EnvVar: config.OpenBrowserEnvVar,
 		},
+		{
+			Name:   config.AllProfilesFlag,
+			Short:  "k",
+			Value:  false,
+			Usage:  "Collect all profiles for a given IdP (implies aws-credentials file output format)",
+			EnvVar: config.AllProfilesEnvVar,
+		},
 	}
 	requiredFlags = []string{"org-domain", "oidc-client-id"}
 )

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -21,19 +21,66 @@ import (
 	"time"
 )
 
-// Credential Convenience representation of an AWS credential.
-type Credential struct {
-	AccessKeyID     string `ini:"aws_access_key_id"     json:"AccessKeyId,omitempty"`
-	SecretAccessKey string `ini:"aws_secret_access_key" json:"SecretAccessKey,omitempty"`
-	SessionToken    string `ini:"aws_session_token"     json:"SessionToken,omitempty"`
+// Credential Interface to represent AWS credentials in different formats.
+type Credential interface {
+	// Trivial function to allow concrete structs to be represented by this
+	// interface.
+	IsCredential() bool
 }
 
-// ProcessCredential Convenience representation of an AWS credential used for process credential format.
-type ProcessCredential struct {
-	Credential
-	Version    int        `json:"Version,omitempty"`
-	Expiration *time.Time `json:"Expiration,omitempty"`
+// CredentialContainer denormalized struct of all the values can be presented in
+// the different credentials formats
+type CredentialContainer struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      *time.Time
+	Version         int
+	Profile         string
 }
+
+// EnvVarCredential representation of an AWS credential for environment
+// variables
+type EnvVarCredential struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+// IsCredential env var credential is a credential
+func (e *EnvVarCredential) IsCredential() bool { return true }
+
+// CredsFileCredential representation of an AWS credential for the AWS
+// credentials file
+type CredsFileCredential struct {
+	AccessKeyID     string `ini:"aws_access_key_id"`
+	SecretAccessKey string `ini:"aws_secret_access_key"`
+	SessionToken    string `ini:"aws_session_token"`
+
+	profile string
+}
+
+// IsCredential creds file credential is a credential
+func (c *CredsFileCredential) IsCredential() bool { return true }
+
+// SetProfile sets the profile name associated with this AWS credential.
+func (c *CredsFileCredential) SetProfile(p string) { c.profile = p }
+
+// Profile returns the profile name associated with this AWS credential.
+func (c CredsFileCredential) Profile() string { return c.profile }
+
+// ProcessCredential Convenience representation of an AWS credential used for
+// process credential format.
+type ProcessCredential struct {
+	AccessKeyID     string     `json:"AccessKeyId,omitempty"`
+	SecretAccessKey string     `json:"SecretAccessKey,omitempty"`
+	SessionToken    string     `json:"SessionToken,omitempty"`
+	Expiration      *time.Time `json:"Expiration,omitempty"`
+	Version         int        `json:"Version,omitempty"`
+}
+
+// IsCredential process credential is a credential
+func (c *ProcessCredential) IsCredential() bool { return true }
 
 // MarshalJSON ensure Expiration date time is formatted RFC 3339 format.
 func (c *ProcessCredential) MarshalJSON() ([]byte, error) {
@@ -54,3 +101,9 @@ func (c *ProcessCredential) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(obj)
 }
+
+// NoopCredential Convenience representation for not printing credentials
+type NoopCredential struct{}
+
+// IsCredential noop credential is a credential
+func (n *NoopCredential) IsCredential() bool { return true }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,10 +123,16 @@ const (
 	LegacyAWSVariablesEnvVar = "OKTA_AWSCLI_LEGACY_AWS_VARIABLES"
 	// OktaOIDCClientIDEnvVar env var const
 	OktaOIDCClientIDEnvVar = "OKTA_AWSCLI_OIDC_CLIENT_ID"
+	// OldOktaOIDCClientIDEnvVar env var const
+	OldOktaOIDCClientIDEnvVar = "OKTA_OIDC_CLIENT_ID"
 	// OktaOrgDomainEnvVar env var const
 	OktaOrgDomainEnvVar = "OKTA_AWSCLI_ORG_DOMAIN"
+	// OldOktaOrgDomainEnvVar env var const
+	OldOktaOrgDomainEnvVar = "OKTA_ORG_DOMAIN"
 	// OktaAWSAccountFederationAppIDEnvVar env var const
 	OktaAWSAccountFederationAppIDEnvVar = "OKTA_AWSCLI_AWS_ACCOUNT_FEDERATION_APP_ID"
+	// OldOktaAWSAccountFederationAppIDEnvVar env var const
+	OldOktaAWSAccountFederationAppIDEnvVar = "OKTA_AWS_ACCOUNT_FEDERATION_APP_ID"
 	// OpenBrowserEnvVar env var const
 	OpenBrowserEnvVar = "OKTA_AWSCLI_OPEN_BROWSER"
 	// PrivateKeyEnvVar env var const
@@ -326,11 +332,21 @@ func readConfig() (Attributes, error) {
 	if attrs.OrgDomain == "" {
 		attrs.OrgDomain = viper.GetString(downCase(OktaOrgDomainEnvVar))
 	}
+	if attrs.OrgDomain == "" {
+		// legacy support OKTA_ORG_DOMAIN
+		attrs.OrgDomain = viper.GetString(downCase(OldOktaOrgDomainEnvVar))
+	}
 	if attrs.OIDCAppID == "" {
 		attrs.OIDCAppID = viper.GetString(downCase(OktaOIDCClientIDEnvVar))
 	}
+	if attrs.OIDCAppID == "" {
+		attrs.OIDCAppID = viper.GetString(downCase(OldOktaOIDCClientIDEnvVar))
+	}
 	if attrs.FedAppID == "" {
 		attrs.FedAppID = viper.GetString(downCase(OktaAWSAccountFederationAppIDEnvVar))
+	}
+	if attrs.FedAppID == "" {
+		attrs.FedAppID = viper.GetString(downCase(OldOktaAWSAccountFederationAppIDEnvVar))
 	}
 	if attrs.AWSIAMIdP == "" {
 		attrs.AWSIAMIdP = viper.GetString(downCase(AWSIAMIdPEnvVar))

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -63,7 +63,7 @@ func NewExec() (*Exec, error) {
 }
 
 // Run Run the executor
-func (e *Exec) Run(oc *oaws.Credential) error {
+func (e *Exec) Run(cc *oaws.CredentialContainer) error {
 	pairs := map[string]string{}
 	// pre-populate pairs with any existing env var starting with "AWS_"
 	for _, kv := range os.Environ() {
@@ -74,9 +74,9 @@ func (e *Exec) Run(oc *oaws.Credential) error {
 		}
 	}
 	// add creds env var names to pairs
-	pairs["AWS_ACCESS_KEY_ID"] = oc.AccessKeyID
-	pairs["AWS_SECRET_ACCESS_KEY"] = oc.SecretAccessKey
-	pairs["AWS_SESSION_TOKEN"] = oc.SessionToken
+	pairs["AWS_ACCESS_KEY_ID"] = cc.AccessKeyID
+	pairs["AWS_SECRET_ACCESS_KEY"] = cc.SecretAccessKey
+	pairs["AWS_SESSION_TOKEN"] = cc.SessionToken
 
 	cmd := osexec.Command(e.name, e.args...)
 	for k, v := range pairs {

--- a/internal/output/aws_credentials_file_test.go
+++ b/internal/output/aws_credentials_file_test.go
@@ -53,12 +53,12 @@ func TestINIFormatCredentialsContent(t *testing.T) {
 	err = f.Close()
 	assert.NoError(t, err)
 
-	awsCreds := &aws.Credential{
+	cfc := &aws.CredsFileCredential{
 		AccessKeyID:     "d",
 		SecretAccessKey: "e",
 		SessionToken:    "f",
 	}
-	config, err := updateConfig(filename, "test", awsCreds, false, false, "")
+	config, err := updateConfig(filename, "test", cfc, false, false, "")
 	assert.NoError(t, err)
 
 	err = config.SaveTo(filename)

--- a/internal/output/envvar.go
+++ b/internal/output/envvar.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
@@ -39,20 +38,21 @@ func NewEnvVar(legacyVars bool) *EnvVar {
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as shell
 // export statements to STDOUT
-func (e *EnvVar) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
+func (e *EnvVar) Output(c *config.Config, oc oaws.Credential) error {
+	evc := oc.(*oaws.EnvVarCredential)
 	if runtime.GOOS == "windows" {
-		fmt.Printf("setx AWS_ACCESS_KEY_ID %s\n", oc.AccessKeyID)
-		fmt.Printf("setx AWS_SECRET_ACCESS_KEY %s\n", oc.SecretAccessKey)
-		fmt.Printf("setx AWS_SESSION_TOKEN %s\n", oc.SessionToken)
+		fmt.Printf("setx AWS_ACCESS_KEY_ID %s\n", evc.AccessKeyID)
+		fmt.Printf("setx AWS_SECRET_ACCESS_KEY %s\n", evc.SecretAccessKey)
+		fmt.Printf("setx AWS_SESSION_TOKEN %s\n", evc.SessionToken)
 		if e.LegacyAWSVariables {
-			fmt.Printf("setx AWS_SECURITY_TOKEN %s\n", oc.SessionToken)
+			fmt.Printf("setx AWS_SECURITY_TOKEN %s\n", evc.SessionToken)
 		}
 	} else {
-		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", oc.AccessKeyID)
-		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", oc.SecretAccessKey)
-		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", oc.SessionToken)
+		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", evc.AccessKeyID)
+		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", evc.SecretAccessKey)
+		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", evc.SessionToken)
 		if e.LegacyAWSVariables {
-			fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", oc.SessionToken)
+			fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", evc.SessionToken)
 		}
 	}
 

--- a/internal/output/noop.go
+++ b/internal/output/noop.go
@@ -17,7 +17,6 @@
 package output
 
 import (
-	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
@@ -31,7 +30,7 @@ func NewNoopCredentials() *NoopCredentials {
 }
 
 // Output Satisfies the Outputter interface and outputs nothing
-func (n *NoopCredentials) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
+func (n *NoopCredentials) Output(c *config.Config, oc oaws.Credential) error {
 	// no-op
 	return nil
 }

--- a/internal/output/process_credentials.go
+++ b/internal/output/process_credentials.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/sts"
 	oaws "github.com/okta/okta-aws-cli/internal/aws"
 	"github.com/okta/okta-aws-cli/internal/config"
 )
@@ -36,16 +35,10 @@ func NewProcessCredentials() *ProcessCredentials {
 
 // Output Satisfies the Outputter interface and outputs AWS credentials as JSON
 // to STDOUT
-func (p *ProcessCredentials) Output(c *config.Config, oc *oaws.Credential, ac *sts.Credentials) error {
-	// See AWS docs: "Note As of this writing, the Version key must be set to 1.
-	// This might increment over time as the structure evolves."
-	poc := &oaws.ProcessCredential{
-		Credential: *oc,
-		Expiration: ac.Expiration,
-		Version:    1,
-	}
+func (p *ProcessCredentials) Output(c *config.Config, oc oaws.Credential) error {
+	pc := oc.(*oaws.ProcessCredential)
 
-	credJSON, err := json.MarshalIndent(poc, "", "  ")
+	credJSON, err := json.MarshalIndent(pc, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -33,4 +33,11 @@ const (
 	XOktaAWSCLIM2MOperation = "m2m"
 	// PassThroughStringNewLineFMT string formatter to make lint happy
 	PassThroughStringNewLineFMT = "%s\n"
+
+	// AccessKeyID AWS creds access key ID
+	AccessKeyID = "AccessKeyID"
+	// SecretAccessKey AWS creds secret access key
+	SecretAccessKey = "SecretAccessKey"
+	// SessionToken AWS creds session tokne
+	SessionToken = "SessionToken"
 )


### PR DESCRIPTION
### Collect all roles for an AWS Fed App (IdP) at once

Based on @daniel-sampliner`s work in #94

`okta-aws-cli` will collect all available AWS IAM Roles for a given Okta AWS
Federation app (IdP) at once.  This is a feature specific to writing the
`$HOME/.aws/credentials` file. Roles will be AWS account alias name (if STS list
aliases is available on the given role) then `-` then abbreviated role name.

```
# AWS account alias "myorg", given IdP associated with "AWS Account Federation"
# and an app associated with two roles.

$ okta-aws-cli web \
    --org-domain test.okta.com \
    --oidc-client-id 0oa5wyqjk6Wm148fE1d7 \
    --write-aws-credentials \
    --all-profiles

? Choose an IdP: AWS Account Federation
Updated profile "myorg-S3-read" in credentials file "/Users/me/.aws/credentials".
Updated profile "myorg-S3-write" in credentials file "/Users/me/.aws/credentials".
```