### PR TITLE
fix(cli): allow running --version without a subcommand

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -198,7 +198,7 @@ func Execute(defaultCommand string) {
 		cmdFound = true
 	}
 	if len(os.Args) >= 2 {
-		if arg := os.Args[1]; arg == "--help" || arg == "-h" || arg == "help" {
+		if arg := os.Args[1]; arg == "--help" || arg == "-h" || arg == "help" || arg == "--version" || arg == "-v" {
 			cmdFound = true
 		}
 	}


### PR DESCRIPTION
This fixes a regression in the v2.0 series where `okta-aws-cli --version` (and `okta-aws-cli -v`) doesn't work.

Expected:

```
okta-aws-cli version 2.0.0-beta.5
```

Actual:

```
Error: unknown flag: --version
Usage:
  okta-aws-cli web [flags]
```

I tested with the `2.0.0-beta.5` binary on linux/amd64.