### PR TITLE
prep v2.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,12 @@ awscli:
   Ops
 ```
 
+## 2.0.0-beta.6 (November 2, 2023)
+
+* New m2m flag `--private-key-file` read private key from file
+* Bug fix panic when okta.yaml is not established (it doesn't have to be established either)
+* Bug fix allowing `--version` w/o sub command [#150](https://github.com/okta/okta-aws-cli/pull/150), thanks [@malept](https://github.com/malept)!
+
 ## 2.0.0-beta.5 (October 13, 2023)
 
 Friendly label matching for IdPs and Roles with `$HOME/.okta/okta.yaml` file can be regular expressions.

--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ These settings are optional unless marked otherwise:
 | Name | Description | Command line flag | ENV var and .env file value |
 |-----|-----|-----|-----|
 | Key ID (kid) (**required**) | The ID of the key stored in the service app | `--key-id [value]` | `OKTA_AWSCLI_KEY_ID` |
-| Private Key (**required**) | PEM (pkcs#1 or pkcs#9) private key whose public key is stored on the service app | `--private-key [value]` | `OKTA_AWSCLI_PRIVATE_KEY` |
+| Private Key (**required** in lieu of private key file) | PEM (pkcs#1 or pkcs#9) private key whose public key is stored on the service app | `--private-key [value]` | `OKTA_AWSCLI_PRIVATE_KEY` |
+| Private Key File (**required** in lieu of private key) | File holding PEM (pkcs#1 or pkcs#9) private key whose public key is stored on the service app | `--private-key-file [value]` | `OKTA_AWSCLI_PRIVATE_KEY_FILE` |
 | Authorization Server ID | The ID of the Okta authorization server, set ID for a custom authorization server, will use default otherwise. Default `default` | `--authz-id [value]` | `OKTA_AWSCLI_AUTHZ_ID` |
 | Custom scope name | The custom scope established in the custom authorization server. Default `okta-m2m-access` | `--custom-scope [value]` | `OKTA_AWSCLI_CUSTOM_SCOPE` |
 

--- a/cmd/root/m2m/m2m.go
+++ b/cmd/root/m2m/m2m.go
@@ -37,8 +37,15 @@ var (
 			Name:   config.PrivateKeyFlag,
 			Short:  "k",
 			Value:  "",
-			Usage:  "Private Key",
+			Usage:  "Private Key (string value)",
 			EnvVar: config.PrivateKeyEnvVar,
+		},
+		{
+			Name:   config.PrivateKeyFileFlag,
+			Short:  "b",
+			Value:  "",
+			Usage:  "Private Key File",
+			EnvVar: config.PrivateKeyFileEnvVar,
 		},
 		{
 			Name:   config.CustomScopeFlag,
@@ -55,7 +62,7 @@ var (
 			EnvVar: config.AuthzIDEnvVar,
 		},
 	}
-	requiredFlags = []string{"org-domain", "oidc-client-id", "aws-iam-role", "key-id", "private-key"}
+	requiredFlags = []interface{}{"org-domain", "oidc-client-id", "aws-iam-role", "key-id", []string{"private-key", "private-key-file"}}
 )
 
 // NewM2MCommand Sets up the m2m cobra sub command

--- a/cmd/root/web/web.go
+++ b/cmd/root/web/web.go
@@ -69,7 +69,7 @@ var (
 			EnvVar: config.AllProfilesEnvVar,
 		},
 	}
-	requiredFlags = []string{"org-domain", "oidc-client-id"}
+	requiredFlags = []interface{}{"org-domain", "oidc-client-id"}
 )
 
 // NewWebCommand Sets up the web cobra sub command

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,8 @@ const (
 	OrgDomainFlag = "org-domain"
 	// PrivateKeyFlag cli flag const
 	PrivateKeyFlag = "private-key"
+	// PrivateKeyFileFlag cli flag const
+	PrivateKeyFileFlag = "private-key-file"
 	// KeyIDFlag cli flag const
 	KeyIDFlag = "key-id"
 	// ProfileFlag cli flag const
@@ -145,6 +147,8 @@ const (
 	OpenBrowserCommandEnvVar = "OKTA_AWSCLI_OPEN_BROWSER_COMMAND"
 	// PrivateKeyEnvVar env var const
 	PrivateKeyEnvVar = "OKTA_AWSCLI_PRIVATE_KEY"
+	// PrivateKeyFileEnvVar env var const
+	PrivateKeyFileEnvVar = "OKTA_AWSCLI_PRIVATE_KEY_FILE"
 	// KeyIDEnvVar env var const
 	KeyIDEnvVar = "OKTA_AWSCLI_KEY_ID"
 	// ProfileEnvVar env var const
@@ -207,6 +211,7 @@ type Config struct {
 	openBrowserCommand  string
 	orgDomain           string
 	privateKey          string
+	privateKeyFile      string
 	profile             string
 	qrCode              bool
 	writeAWSCredentials bool
@@ -236,6 +241,7 @@ type Attributes struct {
 	OpenBrowserCommand  string
 	OrgDomain           string
 	PrivateKey          string
+	PrivateKeyFile      string
 	Profile             string
 	QRCode              bool
 	WriteAWSCredentials bool
@@ -274,6 +280,7 @@ func NewConfig(attrs *Attributes) (*Config, error) {
 		openBrowser:         attrs.OpenBrowser,
 		openBrowserCommand:  attrs.OpenBrowserCommand,
 		privateKey:          attrs.PrivateKey,
+		privateKeyFile:      attrs.PrivateKeyFile,
 		keyID:               attrs.KeyID,
 		profile:             attrs.Profile,
 		qrCode:              attrs.QRCode,
@@ -325,6 +332,7 @@ func readConfig() (Attributes, error) {
 		OpenBrowserCommand:  viper.GetString(OpenBrowserCommandFlag),
 		OrgDomain:           viper.GetString(OrgDomainFlag),
 		PrivateKey:          viper.GetString(PrivateKeyFlag),
+		PrivateKeyFile:      viper.GetString(PrivateKeyFileFlag),
 		KeyID:               viper.GetString(KeyIDFlag),
 		Profile:             viper.GetString(ProfileFlag),
 		QRCode:              viper.GetBool(QRCodeFlag),
@@ -375,6 +383,9 @@ func readConfig() (Attributes, error) {
 	}
 	if attrs.PrivateKey == "" {
 		attrs.PrivateKey = viper.GetString(downCase(PrivateKeyEnvVar))
+	}
+	if attrs.PrivateKeyFile == "" {
+		attrs.PrivateKeyFile = viper.GetString(downCase(PrivateKeyFileEnvVar))
 	}
 	if attrs.KeyID == "" {
 		attrs.KeyID = viper.GetString(downCase(KeyIDEnvVar))
@@ -721,6 +732,17 @@ func (c *Config) PrivateKey() string {
 // SetPrivateKey --
 func (c *Config) SetPrivateKey(privateKey string) error {
 	c.privateKey = privateKey
+	return nil
+}
+
+// PrivateKeyFile --
+func (c *Config) PrivateKeyFile() string {
+	return c.privateKeyFile
+}
+
+// SetPrivateKeyFile --
+func (c *Config) SetPrivateKeyFile(privateKeyFile string) error {
+	c.privateKeyFile = privateKeyFile
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func init() {
 
 const (
 	// Version app version
-	Version = "2.0.0-beta.5"
+	Version = "2.0.0-beta.6"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"

--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -513,9 +513,8 @@ func (w *WebSSOAuthentication) promptForRole(idp string, roleARNs []string) (rol
 // If the fedApp has already been selected via an ask one survey we don't need
 // to pretty print out the IdP name again.
 func (w *WebSSOAuthentication) promptForIDP(idpARNs []string) (idpARN string, err error) {
-	oktaConfig, _ := w.config.OktaConfig()
 	var configIDPs map[string]string
-	if err == nil {
+	if oktaConfig, cErr := w.config.OktaConfig(); cErr == nil {
 		configIDPs = oktaConfig.AWSCLI.IDPS
 	}
 


### PR DESCRIPTION
## 2.0.0-beta.6 (November 2, 2023)

* New m2m flag `--private-key-file` read private key from file
* Bug fix panic when okta.yaml is not established (it doesn't have to be established either)
* Bug fix allowing `--version` w/o sub command [#150](https://github.com/okta/okta-aws-cli/pull/150), thanks [@malept](https://github.com/malept)!