### PR TITLE
Prep v2.0.1 Release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,10 @@ builds:
       - darwin
       - freebsd
     main: ./cmd/okta-aws-cli/
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    binary: '{{ .ProjectName }}'
+    ignore:
+      - goos: windows
+        goarch: amd64
 archives:
   - id: zip
     format: zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.1 (January 31, 2024)
+
+### ENHANCEMENTS
+
+ * Packaged binary's don't have postfix version value on file name [#154](https://github.com/okta/okta-aws-cli/pull/154)
+
+### BUG FIXES
+
+ * Binaries produced by golang for Windows amd64 runtimes are triggering AVs so we will not publish this for the OS/Arch [#166](https://github.com/okta/okta-aws-cli/pull/166)
+ * CLI version incorrectly rev'd on previous release [#164](https://github.com/okta/okta-aws-cli/pull/164)
+
 ## 2.0.0 (January 25, 2024)
 
 V2 GA Release 🎉🎉

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func init() {
 
 const (
 	// Version app version
-	Version = "2.0.0-beta.6"
+	Version = "2.0.1"
 
 	// AWSCredentialsFormat format const
 	AWSCredentialsFormat = "aws-credentials"


### PR DESCRIPTION
## 2.0.1 (January 31, 2024)

### ENHANCEMENTS

 * Packaged binary's don't have postfix version value on file name [#154](https://github.com/okta/okta-aws-cli/pull/154)

### BUG FIXES

 * Binaries produced by golang for Windows amd64 runtimes are triggering AVs so we will not publish this for the OS/Arch [#166](https://github.com/okta/okta-aws-cli/pull/166)
 * CLI version incorrectly rev'd on previous release [#164](https://github.com/okta/okta-aws-cli/pull/164)