### PR TITLE
Fix rocess credentials format bug when `--write-aws-credentials` flag is present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ TBD
 
 ### BUG FIXES
 
-* Open browser and open browser command behavior was fouled in v2 release [#NNN](https://github.com/okta/okta-aws-cli/pull/NNN), thanks [@monde](https://github.com/monde)!
+* Process credentials format was not emitting JSON correctly when `--write-aws-credentials` flag is present [#NNN](https://github.com/okta/okta-aws-cli/pull/NNN), thanks [@monde](https://github.com/monde)!
+* Open browser and open browser command behavior was fouled in v2 release [#172](https://github.com/okta/okta-aws-cli/pull/172), thanks [@monde](https://github.com/monde)!
 
 ## 2.0.1 (January 31, 2024)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,12 +441,12 @@ func readConfig() (Attributes, error) {
 	if !attrs.WriteAWSCredentials {
 		attrs.WriteAWSCredentials = viper.GetBool(downCase(WriteAWSCredentialsEnvVar))
 	}
-	if attrs.WriteAWSCredentials {
-		// writing aws creds option implies "aws-credentials" format
+	if attrs.WriteAWSCredentials && attrs.Format != ProcessCredentialsFormat {
+		// writing aws creds option implies "aws-credentials" format unless format has already been set as process credentials
 		attrs.Format = AWSCredentialsFormat
 	}
-	if attrs.AllProfiles {
-		// writing all aws profiles option implies "aws-credentials" format
+	if attrs.AllProfiles && attrs.Format != ProcessCredentialsFormat {
+		// writing all aws profiles option implies "aws-credentials" format unless format has already been set as process credentials
 		attrs.Format = AWSCredentialsFormat
 	}
 	if !attrs.OpenBrowser {

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -124,12 +124,13 @@ func updateConfig(filename, profile string, cfc *oaws.CredsFileCredential, legac
 }
 
 // updateIni will comment out any keys that are not "aws_access_key_id",
-// "aws_secret_access_key", or "aws_session_token"
+// "aws_secret_access_key", "aws_session_token", "credential_process"
 func updateINI(config *ini.File, profile string, legacyVars bool, expiryVars bool) (*ini.File, error) {
 	ignore := []string{
 		"aws_access_key_id",
 		"aws_secret_access_key",
 		"aws_session_token",
+		"credential_process",
 	}
 	if legacyVars {
 		ignore = append(ignore, "aws_security_token")


### PR DESCRIPTION
Process credentials format was not emitting JSON correctly when `--write-aws-credentials` flag is present.

Closes #169