### PR TITLE
AWS Region CLI flag `--aws-region`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 TBD
 
+### ENHANCEMENTS
+
+* Explicitly set AWS Region with CLI flag `--aws-region` [#174](https://github.com/okta/okta-aws-cli/pull/174), thanks [@euchen-circle](https://github.com/euchen-circle), [@igaskin](https://github.com/igaskin)!
+
 ### BUG FIXES
 
-* Process credentials format was not emitting JSON correctly when `--write-aws-credentials` flag is present [#NNN](https://github.com/okta/okta-aws-cli/pull/NNN), thanks [@monde](https://github.com/monde)!
+* Process credentials format was not emitting JSON correctly when `--write-aws-credentials` flag is present [#177](https://github.com/okta/okta-aws-cli/pull/177), thanks [@monde](https://github.com/monde)!
 * Open browser and open browser command behavior was fouled in v2 release [#172](https://github.com/okta/okta-aws-cli/pull/172), thanks [@monde](https://github.com/monde)!
 
 ## 2.0.1 (January 31, 2024)

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ These global settings are optional unless marked otherwise:
 
 | Name | Description | Command line flag | ENV var and .env file value |
 |-----|-----|-----|-----|
+| AWS Region (**optional**) | AWS region (will override ENV VAR `AWS_REGION` and `AWS_DEFAULT_REGION`) e.g. `us-east-2` | `--aws-region [value]` | `OKTA_AWSCLI_AWS_REGION` |
 | Okta Org Domain (**required**) | Full host and domain name of the Okta org e.g. `test.okta.com` or the custom domain value | `--org-domain [value]` | `OKTA_AWSCLI_ORG_DOMAIN` |
 | OIDC Client ID (**required**) | For `web` the OIDC native application / [Allowed Web SSO Client ID](#allowed-web-sso-client-id), for `m2m` the API services app ID | `--oidc-client-id [value]` | `OKTA_AWSCLI_OIDC_CLIENT_ID` |
 | AWS IAM Role ARN (**optional** for `web`, **required** for `m2m`) | For web preselects the role list to this preferred IAM role for the given IAM Identity Provider. For `m2m` | `--aws-iam-role [value]` | `OKTA_AWSCLI_IAM_ROLE` |

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -86,6 +86,13 @@ func init() {
 			EnvVar: config.FormatEnvVar,
 		},
 		{
+			Name:   config.AWSRegionFlag,
+			Short:  "n",
+			Value:  "",
+			Usage:  "Preset AWS Region",
+			EnvVar: config.AWSRegionEnvVar,
+		},
+		{
 			Name:   config.AWSCredentialsFlag,
 			Short:  "w",
 			Value:  awsCredentialsFilename,

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -25,6 +25,7 @@ import (
 // the different credentials formats
 type CredentialContainer struct {
 	AccessKeyID     string
+	Region          string
 	SecretAccessKey string
 	SessionToken    string
 	Expiration      *time.Time
@@ -44,6 +45,7 @@ type EnvVarCredential struct {
 // credentials file
 type CredsFileCredential struct {
 	AccessKeyID     string `ini:"aws_access_key_id"`
+	Region          string `ini:"region"`
 	SecretAccessKey string `ini:"aws_secret_access_key"`
 	SessionToken    string `ini:"aws_session_token"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,8 @@ const (
 	AWSIAMIdPFlag = "aws-iam-idp"
 	// AWSIAMRoleFlag cli flag const
 	AWSIAMRoleFlag = "aws-iam-role"
+	// AWSRegion cli flag const
+	AWSRegionFlag = "aws-region"
 	// CustomScopeFlag cli flag const
 	CustomScopeFlag = "custom-scope"
 	// DebugFlag cli flag const
@@ -113,6 +115,8 @@ const (
 	AWSIAMRoleEnvVar = "OKTA_AWSCLI_IAM_ROLE"
 	// AWSSessionDurationEnvVar env var const
 	AWSSessionDurationEnvVar = "OKTA_AWSCLI_SESSION_DURATION"
+	// AWSRegionEnvVar env var const
+	AWSRegionEnvVar = "OKTA_AWSCLI_AWS_REGION"
 	// CacheAccessTokenEnvVar env var const
 	CacheAccessTokenEnvVar = "OKTA_AWSCLI_CACHE_ACCESS_TOKEN"
 	// CustomScopeEnvVar env var const
@@ -194,6 +198,7 @@ type Config struct {
 	awsCredentials      string
 	awsIAMIdP           string
 	awsIAMRole          string
+	awsRegion           string
 	awsSessionDuration  int64
 	cacheAccessToken    bool
 	customScope         string
@@ -225,6 +230,7 @@ type Attributes struct {
 	AWSCredentials      string
 	AWSIAMIdP           string
 	AWSIAMRole          string
+	AWSRegion           string
 	AWSSessionDuration  int64
 	CacheAccessToken    bool
 	CustomScope         string
@@ -268,8 +274,7 @@ func NewConfig(attrs *Attributes) (*Config, error) {
 		awsCredentials:      attrs.AWSCredentials,
 		awsIAMIdP:           attrs.AWSIAMIdP,
 		awsIAMRole:          attrs.AWSIAMRole,
-		cacheAccessToken:    attrs.CacheAccessToken,
-		customScope:         attrs.CustomScope,
+		awsRegion:           attrs.AWSRegion,
 		debug:               attrs.Debug,
 		debugAPICalls:       attrs.DebugAPICalls,
 		expiryAWSVariables:  attrs.ExpiryAWSVariables,
@@ -318,6 +323,7 @@ func readConfig() (Attributes, error) {
 		AWSIAMIdP:           viper.GetString(AWSIAMIdPFlag),
 		AWSIAMRole:          viper.GetString(AWSIAMRoleFlag),
 		AWSSessionDuration:  viper.GetInt64(SessionDurationFlag),
+		AWSRegion:           viper.GetString(AWSRegionFlag),
 		CustomScope:         viper.GetString(CustomScopeFlag),
 		Debug:               viper.GetBool(DebugFlag),
 		DebugAPICalls:       viper.GetBool(DebugAPICallsFlag),
@@ -549,6 +555,15 @@ func (c *Config) AWSIAMRole() string {
 func (c *Config) SetAWSIAMRole(role string) error {
 	c.awsIAMRole = role
 	return nil
+}
+
+func (c *Config) SetAWSRegion(region string) error {
+	c.awsRegion = region
+	return nil
+}
+
+func (c *Config) AWSRegion() string {
+	return c.awsRegion
 }
 
 // AWSSessionDuration --

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,7 @@ const (
 	AWSIAMIdPFlag = "aws-iam-idp"
 	// AWSIAMRoleFlag cli flag const
 	AWSIAMRoleFlag = "aws-iam-role"
-	// AWSRegion cli flag const
+	// AWSRegionFlag cli flag const
 	AWSRegionFlag = "aws-region"
 	// CustomScopeFlag cli flag const
 	CustomScopeFlag = "custom-scope"
@@ -557,13 +557,15 @@ func (c *Config) SetAWSIAMRole(role string) error {
 	return nil
 }
 
+// AWSRegion --
+func (c *Config) AWSRegion() string {
+	return c.awsRegion
+}
+
+// SetAWSRegion --
 func (c *Config) SetAWSRegion(region string) error {
 	c.awsRegion = region
 	return nil
-}
-
-func (c *Config) AWSRegion() string {
-	return c.awsRegion
 }
 
 // AWSSessionDuration --

--- a/internal/m2mauth/m2mauth.go
+++ b/internal/m2mauth/m2mauth.go
@@ -114,6 +114,10 @@ func (m *M2MAuthentication) EstablishIAMCredentials() error {
 
 func (m *M2MAuthentication) awsAssumeRoleWithWebIdentity(at *okta.AccessToken) (cc *oaws.CredentialContainer, err error) {
 	awsCfg := aws.NewConfig().WithHTTPClient(m.config.HTTPClient())
+	region := m.config.AWSRegion()
+	if region != "" {
+		awsCfg = awsCfg.WithRegion(region)
+	}
 	sess, err := session.NewSession(awsCfg)
 	if err != nil {
 		return

--- a/internal/output/aws_credentials_file_test.go
+++ b/internal/output/aws_credentials_file_test.go
@@ -58,7 +58,7 @@ func TestINIFormatCredentialsContent(t *testing.T) {
 		SecretAccessKey: "e",
 		SessionToken:    "f",
 	}
-	config, err := updateConfig(filename, "test", cfc, false, false, "")
+	config, err := updateConfig(filename, "test", cfc, false, false, "", "us-east-2")
 	assert.NoError(t, err)
 
 	err = config.SaveTo(filename)
@@ -141,7 +141,7 @@ aws_security_token    = ghi
 		t.Run(test.name, func(t *testing.T) {
 			config, err := ini.Load(test.config)
 			require.NoError(t, err)
-			ini, err := updateINI(config, "default", test.legacy, false)
+			ini, err := updateINI(config, "default", test.legacy, false, "us-east-2")
 			require.NoError(t, err)
 			section := ini.Section(test.section)
 			require.Equal(t, len(test.want), len(section.KeyStrings()))

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -36,8 +36,10 @@ const (
 
 	// AccessKeyID AWS creds access key ID
 	AccessKeyID = "AccessKeyID"
+	// Region region
+	Region = "Region"
 	// SecretAccessKey AWS creds secret access key
 	SecretAccessKey = "SecretAccessKey"
-	// SessionToken AWS creds session tokne
+	// SessionToken AWS creds session token
 	SessionToken = "SessionToken"
 )


### PR DESCRIPTION
Adds AWS Region as a CLI flag for explicitly setting that value.

Closes #160
Closes #161