### PR TITLE
fix: Fix default values in config when using AWS profile argument using AWS profiles in Okta config.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -372,7 +372,7 @@ func NewConfig(attrs *Attributes) (*Config, error) {
 
 func getFlagNameFromProfile(awsProfile string, flag string) string {
 	profileKey := fmt.Sprintf("%s.%s", awsProfile, flag)
-	if awsProfile != "" && viper.IsSet(profileKey) {
+	if awsProfile != "" && viper.Get(profileKey) != "" {
 		// NOTE: If the flag was from a multiple profiles keyed by aws profile
 		// name i.e. `staging.oidc-client-id`, set the base value to that as
 		// well, `oidc-client-id`, such that input validation is satisfied.


### PR DESCRIPTION
Fix logic that determines if the AWS-profile-specific config key has been set - viper InConfig and IsSet appear to always return true, even if the value is not defined in the "profile.key"

Fixes https://github.com/okta/okta-aws-cli/issues/182

This fixes the default AWS credential file location and also the actual value of the AWS profile