### PR TITLE
MatthewJohn's PR 187

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## Major.Minor.Revision (Month Day, Year)
+
+### BUG FIXES
+
+* Fix bug dealing with multiple profiles in okta.yaml [#187](https://github.com/okta/okta-aws-cli/pull/187), thanks [@MatthewJohn](https://github.com/MatthewJohn)!
+
 ## 2.1.0 (February 15, 2024)
 
 ### ENHANCEMENTS
 
-* Multiple okta-aws-cli configurations in `okta.yaml` by AWS profile name.
- [#162](https://github.com/okta/okta-aws-cli/pull/162), thanks [@MatthewJohn](https://github.com/MatthewJohn)!
+* Multiple okta-aws-cli configurations in `okta.yaml` by AWS profile name.  [#162](https://github.com/okta/okta-aws-cli/pull/162), thanks [@MatthewJohn](https://github.com/MatthewJohn)!
 
 * Explicitly set AWS Region with CLI flag `--aws-region` [#174](https://github.com/okta/okta-aws-cli/pull/174), thanks [@euchen-circle](https://github.com/euchen-circle), [@igaskin](https://github.com/igaskin)!
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -372,7 +372,7 @@ func NewConfig(attrs *Attributes) (*Config, error) {
 
 func getFlagNameFromProfile(awsProfile string, flag string) string {
 	profileKey := fmt.Sprintf("%s.%s", awsProfile, flag)
-	if awsProfile != "" && viper.IsSet(profileKey) {
+	if awsProfile != "" && viper.Get(profileKey) != "" {
 		// NOTE: If the flag was from a multiple profiles keyed by aws profile
 		// name i.e. `staging.oidc-client-id`, set the base value to that as
 		// well, `oidc-client-id`, such that input validation is satisfied.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -429,7 +429,7 @@ func readConfig() (Attributes, error) {
 		PrivateKey:          viper.GetString(getFlagNameFromProfile(awsProfile, PrivateKeyFlag)),
 		PrivateKeyFile:      viper.GetString(getFlagNameFromProfile(awsProfile, PrivateKeyFileFlag)),
 		KeyID:               viper.GetString(getFlagNameFromProfile(awsProfile, KeyIDFlag)),
-		Profile:             viper.GetString(getFlagNameFromProfile(awsProfile, ProfileFlag)),
+		Profile:             awsProfile,
 		QRCode:              viper.GetBool(getFlagNameFromProfile(awsProfile, QRCodeFlag)),
 		WriteAWSCredentials: viper.GetBool(getFlagNameFromProfile(awsProfile, WriteAWSCredentialsFlag)),
 	}


### PR DESCRIPTION
Fix default values in config when using AWS profile argument using AWS profiles in Okta config.

Fix logic that determines if the AWS-profile-specific config key has been set - viper InConfig and IsSet appear to always return true, even if the value is not defined in the "profile.key"

Fixes https://github.com/okta/okta-aws-cli/issues/182

Profile value is already set, remove unnecessary function call.

Closes #187 
Closes #182