### PR TITLE
Default value for profile argument should be the default profile

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -74,7 +74,7 @@ func init() {
 		{
 			Name:   config.ProfileFlag,
 			Short:  "p",
-			Value:  "",
+			Value:  "default",
 			Usage:  "AWS Profile",
 			EnvVar: config.ProfileEnvVar,
 		},


### PR DESCRIPTION
In the list of arguments in the README.md for `okta-aws-cli` it is written:


Name | Description | Command line flag | ENV var and .env file value
-- | -- | -- | --
Profile | Default is default | --profile [value] | OKTA_AWSCLI_PROFILE


However, when using okta-aws-cli v2.1.2, this is the result you get when nothing is specified, despite a default profile being present:

```shell
$ okta-aws-cli web
Error: missing flags:
  --org-domain
  --oidc-client-id
```

This PR therefore sets the default value for the profile to be `default` as described in the documentation.