### PR TITLE
fix: adds region from env var to config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,6 +494,9 @@ func readConfig() (Attributes, error) {
 	if !attrs.AllProfiles {
 		attrs.AllProfiles = viper.GetBool(downCase(AllProfilesEnvVar))
 	}
+	if attrs.AWSRegion == "" {
+		attrs.AWSRegion = viper.GetString(downCase(AWSRegionEnvVar))
+	}
 
 	// if session duration is 0, inspect the ENV VAR for a value, else set
 	// a default of 3600


### PR DESCRIPTION
This PR is to fix the issue when you set the OKTA_AWSCLI_AWS_REGION via env var the region does not get saved in the profile. If we add the env var value to config here it gets saved as expected.