### PR TITLE
Paginate apps and better support for non-Admin users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.0.0
+        uses: goreleaser/goreleaser-action@v6.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.X.X (MM d, 2024)
+
+### ENHANCEMENTS
+
+* Seamless support for non-Admin users if OIDC app has `okta.users.read.self` grant [#TDB](https://github.com/okta/okta-aws-cli/pull/TBD), thanks [@monde](https://github.com/monde)!
+* Improve README with note about device state in policy [#205](https://github.com/okta/okta-aws-cli/pull/205), thanks [@ramgandhi-okta](https://github.com/ramgandhi-okta)!
+* Correct m2m typo in README [#201](https://github.com/okta/okta-aws-cli/pull/201), thanks [@stefan-lsx](https://github.com/stefan-lsx)!
+
+### BUG FIXES
+
+* Paginating more than 200 apps on `GET /api/v1/apps` not implemented [#212](https://github.com/okta/okta-aws-cli/pull/212), thanks [@pmgalea](https://github.com/pmgalea)!
+* Respect `OKTA_AWSCLI_AWS_REGION` env var value when saving to the profile [#203](https://github.com/okta/okta-aws-cli/pull/203), thanks [@sudolibre](https://github.com/sudolibre)!
+* Default profile value not correctly set to `default` [#200](https://github.com/okta/okta-aws-cli/pull/200), thanks [@mantoine96](https://github.com/mantoine96)!
+
 ## 2.1.2 (February 27, 2024)
 
 ### BUG FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 2.X.X (MM d, 2024)
+## 2.2.0 (July 3, 2024)
 
 ### ENHANCEMENTS
 
-* Seamless support for non-Admin users if OIDC app has `okta.users.read.self` grant [#TDB](https://github.com/okta/okta-aws-cli/pull/TBD), thanks [@monde](https://github.com/monde)!
+* Seamless support for non-Admin users if OIDC app has `okta.users.read.self` grant [#213](https://github.com/okta/okta-aws-cli/pull/213), thanks [@monde](https://github.com/monde)!
 * Improve README with note about device state in policy [#205](https://github.com/okta/okta-aws-cli/pull/205), thanks [@ramgandhi-okta](https://github.com/ramgandhi-okta)!
 * Correct m2m typo in README [#201](https://github.com/okta/okta-aws-cli/pull/201), thanks [@stefan-lsx](https://github.com/stefan-lsx)!
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+require (
+	github.com/BurntSushi/toml v1.4.0 // indirect
+	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/AlecAivazis/survey/v2 v2.3.6 h1:NvTuVHISgTHEHeBFqt6BHOe4Ny/NwGZr7w+F8S9ziyw=
 github.com/AlecAivazis/survey/v2 v2.3.6/go.mod h1:4AuI9b7RjAR+G7v9+C4YSlX/YL3K3cWNXgWXOhllqvI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ func init() {
 
 const (
 	// Version app version
-	Version = "2.1.2"
+	Version = "2.2.0"
 
 	////////////////////////////////////////////////////////////
 	// FORMATS

--- a/internal/okta/application.go
+++ b/internal/okta/application.go
@@ -16,8 +16,8 @@
 
 package okta
 
-// Application Okta API application object
-// See: https://developer.okta.com/docs/reference/api/apps/#application-object
+// Application Okta API application object.
+// See: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/#tag/Application/operation/listApplications
 type Application struct {
 	ID       string `json:"id"`
 	Label    string `json:"label"`
@@ -29,4 +29,12 @@ type Application struct {
 			WebSSOClientID      string `json:"webSSOAllowedClient"`
 		} `json:"app"`
 	} `json:"settings"`
+}
+
+// ApplicationLink Okta API application link object.
+// See: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listAppLinks
+type ApplicationLink struct {
+	ID    string `json:"appInstanceId"`
+	Label string `json:"label"`
+	Name  string `json:"appName"`
 }

--- a/internal/paginator/paginator.go
+++ b/internal/paginator/paginator.go
@@ -63,8 +63,10 @@ func (pgntr *Paginator) Do(req *http.Request, v interface{}) (*PaginateResponse,
 
 func (pgntr *Paginator) GetItems(v interface{}) (resp *PaginateResponse, err error) {
 	params := url.Values{}
-	for k, v := range *pgntr.params {
-		params.Add(k, v)
+	if pgntr.params != nil {
+		for k, v := range *pgntr.params {
+			params.Add(k, v)
+		}
 	}
 	pgntr.url.RawQuery = params.Encode()
 

--- a/internal/paginator/paginator.go
+++ b/internal/paginator/paginator.go
@@ -1,0 +1,209 @@
+package paginator
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+type PaginateResponse struct {
+	*http.Response
+	pgntr    *Paginator
+	Self     string
+	NextPage string
+}
+
+func (r *PaginateResponse) HasNextPage() bool {
+	return r.NextPage != ""
+}
+
+func (r *PaginateResponse) Next(v interface{}) (*PaginateResponse, error) {
+	req, err := http.NewRequest(http.MethodGet, r.NextPage, nil)
+	for k, v := range *r.pgntr.headers {
+		req.Header.Add(k, v)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return r.pgntr.Do(req, v)
+}
+
+type Paginator struct {
+	httpClient *http.Client
+	url        *url.URL
+	headers    *map[string]string
+	params     *map[string]string
+}
+
+func NewPaginator(httpClient *http.Client, url *url.URL, headers *map[string]string, params *map[string]string) *Paginator {
+	pgntr := Paginator{
+		httpClient: httpClient,
+		url:        url,
+		headers:    headers,
+		params:     params,
+	}
+	return &pgntr
+}
+
+func (pgntr *Paginator) Do(req *http.Request, v interface{}) (*PaginateResponse, error) {
+	resp, err := pgntr.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return buildPaginateResponse(resp, pgntr, &v)
+}
+
+func (pgntr *Paginator) GetItems(v interface{}) (resp *PaginateResponse, err error) {
+	params := url.Values{}
+	for k, v := range *pgntr.params {
+		params.Add(k, v)
+	}
+	pgntr.url.RawQuery = params.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, pgntr.url.String(), nil)
+	if err != nil {
+		return
+	}
+	for k, v := range *pgntr.headers {
+		req.Header.Add(k, v)
+	}
+
+	resp, err = pgntr.Do(req, v)
+	return
+}
+
+func newPaginateResponse(r *http.Response, pgntr *Paginator) *PaginateResponse {
+	response := &PaginateResponse{Response: r, pgntr: pgntr}
+	links := r.Header["Link"]
+
+	if len(links) == 0 {
+		return response
+
+	}
+	for _, link := range links {
+		splitLinkHeader := strings.Split(link, ";")
+		if len(splitLinkHeader) < 2 {
+			continue
+		}
+		linkStr := strings.TrimRight(strings.TrimLeft(splitLinkHeader[0], "<"), ">")
+		if urlURL, err := url.Parse(linkStr); err == nil {
+			if r.Request != nil {
+				q := r.Request.URL.Query()
+				for k, v := range urlURL.Query() {
+					q.Set(k, v[0])
+				}
+				urlURL.RawQuery = q.Encode()
+			}
+			if strings.Contains(link, `rel="self"`) {
+				response.Self = urlURL.String()
+			}
+			if strings.Contains(link, `rel="next"`) {
+				response.NextPage = urlURL.String()
+			}
+		}
+	}
+
+	return response
+}
+
+func buildPaginateResponse(resp *http.Response, pgntr *Paginator, v interface{}) (*PaginateResponse, error) {
+	ct := resp.Header.Get("Content-Type")
+	response := newPaginateResponse(resp, pgntr)
+	err := checkResponseForError(resp)
+	if err != nil {
+		return response, err
+	}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	copyBodyBytes := make([]byte, len(bodyBytes))
+	copy(copyBodyBytes, bodyBytes)
+	_ = resp.Body.Close()                                // close it to avoid memory leaks
+	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // restore the original response body
+	if len(copyBodyBytes) == 0 {
+		return response, nil
+	}
+	switch {
+	case strings.Contains(ct, "application/xml"):
+		err = xml.NewDecoder(bytes.NewReader(copyBodyBytes)).Decode(v)
+	case strings.Contains(ct, "application/json"):
+		err = json.NewDecoder(bytes.NewReader(copyBodyBytes)).Decode(v)
+	case strings.Contains(ct, "application/octet-stream"):
+		// since the response is arbitrary binary data, we leave it to the user to decode it
+		return response, nil
+	default:
+		return nil, errors.New("could not build a response for type: " + ct)
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func checkResponseForError(resp *http.Response) error {
+	statusCode := resp.StatusCode
+	if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
+		return nil
+	}
+	e := Error{}
+	if (statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden) &&
+		strings.Contains(resp.Header.Get("Www-Authenticate"), "Bearer") {
+		for _, v := range strings.Split(resp.Header.Get("Www-Authenticate"), ", ") {
+			if strings.Contains(v, "error_description") {
+				_, err := toml.Decode(v, &e)
+				if err != nil {
+					e.ErrorSummary = "unauthorized"
+				}
+				return &e
+			}
+		}
+	}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	copyBodyBytes := make([]byte, len(bodyBytes))
+	copy(copyBodyBytes, bodyBytes)
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	_ = json.NewDecoder(bytes.NewReader(copyBodyBytes)).Decode(&e)
+	if statusCode == http.StatusInternalServerError {
+		e.ErrorSummary += fmt.Sprintf(", x-okta-request-id=%s", resp.Header.Get("x-okta-request-id"))
+	}
+	return &e
+}
+
+type Error struct {
+	ErrorMessage     string                   `json:"error"`
+	ErrorDescription string                   `json:"error_description"`
+	ErrorCode        string                   `json:"errorCode,omitempty"`
+	ErrorSummary     string                   `json:"errorSummary,omitempty" toml:"error_description"`
+	ErrorLink        string                   `json:"errorLink,omitempty"`
+	ErrorId          string                   `json:"errorId,omitempty"`
+	ErrorCauses      []map[string]interface{} `json:"errorCauses,omitempty"`
+}
+
+func (e *Error) Error() string {
+	formattedErr := "the API returned an unknown error"
+	if e.ErrorDescription != "" {
+		formattedErr = fmt.Sprintf("the API returned an error: %s", e.ErrorDescription)
+	} else if e.ErrorSummary != "" {
+		formattedErr = fmt.Sprintf("the API returned an error: %s", e.ErrorSummary)
+	}
+	if len(e.ErrorCauses) > 0 {
+		var causes []string
+		for _, cause := range e.ErrorCauses {
+			for key, val := range cause {
+				causes = append(causes, fmt.Sprintf("%s: %v", key, val))
+			}
+		}
+		formattedErr = fmt.Sprintf("%s. Causes: %s", formattedErr, strings.Join(causes, ", "))
+	}
+	return formattedErr
+}


### PR DESCRIPTION
Bringing in @pmgalea's bug fix for paginating apps. Also a better implementation of supporting non-Admin users. Set up as 2.2.0 release.

* Seamless support for non-Admin users if OIDC app has `okta.users.read.self` grant [#213](https://github.com/okta/okta-aws-cli/pull/213), thanks [@monde](https://github.com/monde)!
* Paginating more than 200 apps on `GET /api/v1/apps` not implemented [#212](https://github.com/okta/okta-aws-cli/pull/212), thanks [@pmgalea](https://github.com/pmgalea)!