### PR TITLE
Needed goreleaser adjustments.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -33,9 +34,4 @@ snapshot:
 release:
   draft: true
 changelog:
-  skip: true
-  #sort: asc
-  #filters:
-  #  exclude:
-  #    - '^docs:'
-  #    - '^test:'
+  disable: true

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
+	github.com/BurntSushi/toml v1.4.0
 	github.com/aws/aws-sdk-go v1.44.94
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -24,10 +25,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require (
-	github.com/BurntSushi/toml v1.4.0 // indirect
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
-)
+require golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,6 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
-golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
https://goreleaser.com/blog/goreleaser-v2/
https://goreleaser.com/customization/changelog/

Fixing https://github.com/okta/okta-aws-cli/actions/runs/9783071850/job/27010814665

```
Run goreleaser/goreleaser-action@v6.0.0
Warning: You are using 'latest' as default version. Will lock to '~> v2'.
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.0.1/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/166b5861-3334-4801-89a4-f4fbb61c3a17 -f /home/runner/work/_temp/c7[12](https://github.com/okta/okta-aws-cli/actions/runs/9783071850/job/27010814665#step:6:13)20f5-cdac-4d03-8ec9-b0b58ec6b9b6
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser release --clean
  • starting release...
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser' failed with exit code 1
```