### PR TITLE
Reset cached access token on `invalid_grant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.3.0 (July 12, 2024)
+
+### ENHANCEMENTS
+
+* New command `okta-aws-cli list-profiles` helper to inspect profiles in okta.yaml [#222](https://github.com/okta/okta-aws-cli/pull/222), thanks [@pmgalea](https://github.com/pmgalea)!
+* GH releases publish Windows artifact to Chocolatey [#215](https://github.com/okta/okta-aws-cli/pull/215), thanks [@monde](https://github.com/monde)!
+* Better retry for when the cached access token has been invalidated outside of okta-aws-cli's control. [#220](https://github.com/okta/okta-aws-cli/pull/220), thanks [@monde](https://github.com/monde)!
+* Print a warning at first run if otka.yaml is malformed. [#220](https://github.com/okta/okta-aws-cli/pull/220), thanks [@monde](https://github.com/monde)!
+
+### BUG FIXES
+
+*  Correct "default" profile flaw introduced in 2.2.0 release [#220](https://github.com/okta/okta-aws-cli/pull/220), thanks [@monde](https://github.com/monde)!
+*  Continue polling instead of exit on a 400 "slow_down" API error [#220](https://github.com/okta/okta-aws-cli/pull/220), thanks [@monde](https://github.com/monde)!
+
 ## 2.2.0 (July 3, 2024)
 
 ### ENHANCEMENTS

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,8 @@ build: fmtcheck
 	go build -o $(GOBIN)/okta-aws-cli cmd/okta-aws-cli/main.go
 
 clean:
-	go clean -cache -testcache ./...
-
-clean-all:
-	go clean -cache -testcache -modcache ./...
+	rm -fr dist/
+	go clean -testcache
 
 fmt: tools # Format the code
 	@$(GOFMT) -l -w .

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -76,7 +76,7 @@ func init() {
 		{
 			Name:   config.ProfileFlag,
 			Short:  "p",
-			Value:  "default",
+			Value:  "",
 			Usage:  "AWS Profile",
 			EnvVar: config.ProfileEnvVar,
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ func init() {
 
 const (
 	// Version app version
-	Version = "2.2.0"
+	Version = "2.3.0"
 
 	////////////////////////////////////////////////////////////
 	// FORMATS

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -420,7 +420,17 @@ func readConfig() (Attributes, error) {
 		}
 	}
 
+	// config loading order
+	// 1) command line flags 2) environment variables, 3) .env file
 	awsProfile := viper.GetString(ProfileFlag)
+	// mimic AWS CLI behavior, if profile value is not set by flag check
+	// the ENV VAR, else set to "default"
+	if awsProfile == "" {
+		awsProfile = viper.GetString(downCase(ProfileEnvVar))
+	}
+	if awsProfile == "" {
+		awsProfile = "default"
+	}
 
 	attrs := Attributes{
 		AllProfiles:         viper.GetBool(getFlagNameFromProfile(awsProfile, AllProfilesFlag)),
@@ -452,15 +462,6 @@ func readConfig() (Attributes, error) {
 	}
 	if attrs.Format == "" {
 		attrs.Format = EnvVarFormat
-	}
-
-	// mimic AWS CLI behavior, if profile value is not set by flag check
-	// the ENV VAR, else set to "default"
-	if attrs.Profile == "" {
-		attrs.Profile = viper.GetString(downCase(ProfileEnvVar))
-	}
-	if attrs.Profile == "" {
-		attrs.Profile = "default"
 	}
 
 	// Viper binds ENV VARs to a lower snake version, set the configs with them

--- a/internal/okta/apierror.go
+++ b/internal/okta/apierror.go
@@ -16,8 +16,87 @@
 
 package okta
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	// APIErrorMessageBase base API error message
+	APIErrorMessageBase = "the API returned an unknown error"
+	// APIErrorMessageWithErrorDescription API error message with description
+	APIErrorMessageWithErrorDescription = "the API returned an error: %s"
+	// APIErrorMessageWithErrorSummary API error message with summary
+	APIErrorMessageWithErrorSummary = "the API returned an error: %s"
+	// HTTPHeaderWwwAuthenticate Www-Authenticate header
+	HTTPHeaderWwwAuthenticate = "Www-Authenticate"
+)
+
 // APIError Wrapper for Okta API error
 type APIError struct {
-	Error            string `json:"error,omitempty"`
-	ErrorDescription string `json:"error_description,omitempty"`
+	ErrorType        string                   `json:"error"`
+	ErrorDescription string                   `json:"error_description"`
+	ErrorCode        string                   `json:"errorCode,omitempty"`
+	ErrorSummary     string                   `json:"errorSummary,omitempty" toml:"error_description"`
+	ErrorLink        string                   `json:"errorLink,omitempty"`
+	ErrorID          string                   `json:"errorId,omitempty"`
+	ErrorCauses      []map[string]interface{} `json:"errorCauses,omitempty"`
+}
+
+// Error String-ify the Error
+func (e *APIError) Error() string {
+	formattedErr := APIErrorMessageBase
+	if e.ErrorDescription != "" {
+		formattedErr = fmt.Sprintf(APIErrorMessageWithErrorDescription, e.ErrorDescription)
+	} else if e.ErrorSummary != "" {
+		formattedErr = fmt.Sprintf(APIErrorMessageWithErrorSummary, e.ErrorSummary)
+	}
+	if len(e.ErrorCauses) > 0 {
+		var causes []string
+		for _, cause := range e.ErrorCauses {
+			for key, val := range cause {
+				causes = append(causes, fmt.Sprintf("%s: %v", key, val))
+			}
+		}
+		formattedErr = fmt.Sprintf("%s. Causes: %s", formattedErr, strings.Join(causes, ", "))
+	}
+	return formattedErr
+}
+
+// NewAPIError Constructor for Okta API error, will return nil if the response
+// is not an error.
+func NewAPIError(resp *http.Response) error {
+	statusCode := resp.StatusCode
+	if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
+		return nil
+	}
+	e := APIError{}
+	if (statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden) &&
+		strings.Contains(resp.Header.Get(HTTPHeaderWwwAuthenticate), "Bearer") {
+		for _, v := range strings.Split(resp.Header.Get(HTTPHeaderWwwAuthenticate), ", ") {
+			if strings.Contains(v, "error_description") {
+				_, err := toml.Decode(v, &e)
+				if err != nil {
+					e.ErrorSummary = "unauthorized"
+				}
+				return &e
+			}
+		}
+	}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	copyBodyBytes := make([]byte, len(bodyBytes))
+	copy(copyBodyBytes, bodyBytes)
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	_ = json.NewDecoder(bytes.NewReader(copyBodyBytes)).Decode(&e)
+	if statusCode == http.StatusInternalServerError {
+		e.ErrorSummary += fmt.Sprintf(", x-okta-request-id=%s", resp.Header.Get("x-okta-request-id"))
+	}
+	return &e
 }

--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -948,7 +948,7 @@ func (w *WebSSOAuthentication) accessToken(deviceAuth *okta.DeviceAuthorization)
 			if err != nil {
 				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API error body %q", string(bodyBytes)))
 			}
-			if apiErr.ErrorType != "authorization_pending" {
+			if apiErr.ErrorType != "authorization_pending" && apiErr.ErrorType != "slow_down" {
 				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API polling error %q - %q", apiErr.ErrorType, apiErr.ErrorDescription))
 			}
 

--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -28,7 +28,6 @@ import (
 	"net/url"
 	"os"
 	osexec "os/exec"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -723,16 +722,9 @@ func (w *WebSSOAuthentication) fetchSSOWebToken(clientID, awsFedAppID string, at
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		baseErrStr := "fetching SSO web token received API response %q"
-
-		var apiErr okta.APIError
-		err = json.NewDecoder(resp.Body).Decode(&apiErr)
-		if err != nil {
-			return nil, fmt.Errorf(baseErrStr, resp.Status)
-		}
-
-		return nil, fmt.Errorf(baseErrStr+okta.AccessTokenErrorFormat, resp.Status, apiErr.Error, apiErr.ErrorDescription)
+	err = okta.NewAPIError(resp)
+	if err != nil {
+		return nil, err
 	}
 
 	token = &okta.AccessToken{}
@@ -956,8 +948,8 @@ func (w *WebSSOAuthentication) accessToken(deviceAuth *okta.DeviceAuthorization)
 			if err != nil {
 				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API error body %q", string(bodyBytes)))
 			}
-			if apiErr.Error != "authorization_pending" {
-				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API polling error %q - %q", apiErr.Error, apiErr.ErrorDescription))
+			if apiErr.ErrorType != "authorization_pending" {
+				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API polling error %q - %q", apiErr.ErrorType, apiErr.ErrorDescription))
 			}
 
 			return errors.New("continue polling")
@@ -1120,15 +1112,37 @@ func (w *WebSSOAuthentication) isClassicOrg() bool {
 	return false
 }
 
+// cachedAccessTokenPath Path to the cached access token in $HOME/.okta/awscli-access-token.json
+func cachedAccessTokenPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, dotOktaDir, tokenFileName), nil
+}
+
+// RemoveCachedAccessToken Remove cached access token if it exists. Returns true
+// if the file exists was reremoved, swallows errors otherwise.
+func RemoveCachedAccessToken() bool {
+	accessTokenPath, err := cachedAccessTokenPath()
+	if err != nil {
+		return false
+	}
+	if os.Remove(accessTokenPath) != nil {
+		return false
+	}
+
+	return true
+}
+
 // cachedAccessToken will returned the cached access token if it exists and is
 // not expired.
 func (w *WebSSOAuthentication) cachedAccessToken() (at *okta.AccessToken) {
-	homeDir, err := os.UserHomeDir()
+	accessTokenPath, err := cachedAccessTokenPath()
 	if err != nil {
 		return
 	}
-	configPath := filepath.Join(homeDir, dotOktaDir, tokenFileName)
-	atJSON, err := os.ReadFile(configPath)
+	atJSON, err := os.ReadFile(accessTokenPath)
 	if err != nil {
 		return
 	}
@@ -1158,15 +1172,12 @@ func (w *WebSSOAuthentication) cacheAccessToken(at *okta.AccessToken) {
 		return
 	}
 
-	cUser, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
-	if cUser.HomeDir == "" {
-		return
-	}
 
-	oktaDir := filepath.Join(cUser.HomeDir, dotOktaDir)
+	oktaDir := filepath.Join(homeDir, dotOktaDir)
 	// noop if dir exists
 	err = os.MkdirAll(oktaDir, 0o700)
 	if err != nil {
@@ -1178,16 +1189,21 @@ func (w *WebSSOAuthentication) cacheAccessToken(at *okta.AccessToken) {
 		return
 	}
 
-	configPath := filepath.Join(cUser.HomeDir, dotOktaDir, tokenFileName)
+	configPath := filepath.Join(homeDir, dotOktaDir, tokenFileName)
 	_ = os.WriteFile(configPath, atJSON, 0o600)
 }
 
-func (w *WebSSOAuthentication) consolePrint(format string, a ...any) {
-	if w.config.IsProcessCredentialsFormat() {
+// ConsolePrint printf formatted warning messages.
+func ConsolePrint(config *config.Config, format string, a ...any) {
+	if config.IsProcessCredentialsFormat() {
 		return
 	}
 
 	fmt.Fprintf(os.Stderr, format, a...)
+}
+
+func (w *WebSSOAuthentication) consolePrint(format string, a ...any) {
+	ConsolePrint(w.config, format, a...)
 }
 
 // fetchAllAWSCredentialsWithSAMLRole Gets all AWS Credentials with an STS Assume Role with SAML AWS API call.


### PR DESCRIPTION
Better retry for when the cached access token has been invalidated outside of `okta-aws-cli`'s control.

* Better retry for when the cached access token has been invalidated outside of okta-aws-cli's control
* Print a warning at first run if otka.yaml is malformed
*  Correct "default" profile flaw introduced in 2.2.0 release
*  Continue polling instead of exit on a 400 "slow_down" API error
* New command `okta-aws-cli list-profiles`