### PR TITLE
Fix output formatting bug introduced in 9f8a7ec

### DIFF
--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -275,7 +275,7 @@ func (w *WebSSOAuthentication) selectFedApp(apps []*okta.Application) (string, e
 				if err != nil {
 					return "", err
 				}
-				w.config.Logger.Warn(rich)
+				w.config.Logger.Warn(rich + "\n")
 			}
 
 			return app.ID, nil
@@ -491,7 +491,7 @@ func (w *WebSSOAuthentication) promptForRole(idp string, roleARNs []string) (rol
 			if err != nil {
 				return "", err
 			}
-			w.config.Logger.Warn(rich)
+			w.config.Logger.Warn(rich + "\n")
 		}
 		return roleARN, nil
 	}
@@ -552,7 +552,7 @@ func (w *WebSSOAuthentication) promptForIDP(idpARNs []string) (idpARN string, er
 		if err != nil {
 			return "", err
 		}
-		w.config.Logger.Warn(rich)
+		w.config.Logger.Warn(rich + "\n")
 		return idpARN, nil
 	}
 


### PR DESCRIPTION
9f8a7ec changed stdout/stderr output for several strings.  This PR fixes the ones I've found that ended up missing the newline when transitioning from fmt.Fprintln() to a Logger.Warn().