### PR TITLE
New `direct` command for Direct Authentication (out-of-bounds MFA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.0 (May 20, 2025)
+
+* New `direct` command for OOB MFA password grant auth flow [#277](https://github.com/okta/okta-aws-cli/pull/277), thanks [@monde](https://github.com/monde)!
+
+### ENHANCEMENTS
+
 ## 2.4.1 (February 10, 2025)
 
 ### BUG FIXES

--- a/README.md
+++ b/README.md
@@ -354,13 +354,23 @@ $ okta-aws-cli direct \
 }
 ```
 
-The `direct` command makes use of the (direct
-authorization)[https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/]
+The `direct` command makes use of the [direct
+authorization](https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/)
 flow that uses a username/password grant. It is a multifactor authentication
 flow doing push to [Okta
 Verify](https://help.okta.com/en-us/content/topics/mobile/okta-verify-overview.htm)
 for the second factor. This will allow for a user experience similar to Nike
 Gimme Creds on a Classic classic org with a username and password.
+
+Follow the directions in the [direct
+authorization](https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/)
+documentation to set up the required resources for this flow. The documentation
+specifically covers
+
+- authenticator settings for your org 
+- setting up an authorization server 
+- setting up the up the OIDC app app 
+- required authentication policy settings
 
 When executed `okta-aws-cli direct` requests an access token that is associated
 with the Okta service application. The token is then exchanged and challenged

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ retrieve AWS IAM temporary credentials for use in AWS CLI, AWS SDKs, and other
 tools accessing the AWS API. It has two primary commands:
 
 - `web` - combined human and device authorization
-- `m2m` -  headless authorization
+- `m2m` - headless authorization
+- `direct` - [direct authorization](https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/)  (OOB MFA)
 
 ```shell
  # *nix, export statements
@@ -26,10 +27,11 @@ SETX AWS_SESSION_TOKEN AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5T...
 
 ```
 
-The result of both the `web` and `m2m` operations is to secure and emit [IAM temporary
+The result of both the `web`, `m2m`, and `direct` operations are to secure and
+emit [IAM temporary
 credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).
-The credentials have three different output formats that are chosen by the user:
-[environment
+The credentials have three different output formats that are chosen by the
+user: [environment
 variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html),
 AWS [credentials
 file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html),
@@ -45,11 +47,13 @@ format.
      - [Multiple AWS environments](#multiple-aws-environments)
  - [M2M Command](#m2m-command)
    - [M2M Command Requirements](#m2m-command-requirements)
+ - [Direct Command](#direct-command)
+   - [Direct Command Requirements](#direct-command-requirements)
  - [List-Profiles Command](#list-profiles-command)
  - [Configuration](#configuration)
    - [Global settings](#global-settings)
    - [Web command settings](#web-command-settings)
-   - [M2M command settings](#m2m-command-settings)
+   - [Direct command settings](#direct-command-settings)
    - [Friendly IdP and Role menu labels](#friendly-idp-and-role-menu-labels)
    - [Configuration by profile name](#configuration-by-profile-name)
  - [Debug okta.yaml](#debug-oktayaml)
@@ -68,6 +72,7 @@ format.
 | (empty) | When executed without a subcommand **and** without arguments `okta-aws-cli` will print the online help and exit. With arguments it defaults to the `web` command. |
 | `web` | Human oriented retrieval of temporary IAM credentials through Okta authentication and device authorization. |
 | `m2m` | Machine/headless oriented retrieval of temporary IAM credentials through Okta authentication with a private key. **IMPORTANT!** This a not a feature intended for a human use case. Be sure to use industry state of the art secrets management techniques with the private key. |
+| `direct` | Human or machine/headless oriented retrieval of temporary IAM credentials through out-of-bounds MFA [Direct Authentication](https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/) |
 | `list-profiles` | Lists profile names in ~/.okta/okta.yaml. |
 | `debug` | Debug okta.yaml config file and exit. |
 
@@ -193,6 +198,9 @@ Okta Console.
 use industry state of the art secrets management techniques with the private
 key.***
 
+**NOTE**: The `m2m` command only operates with an Okta OIDC app, not the Okta
+AWS Federation app.
+
 ```shell
 # This example presumes its arguments are set as environment variables such as
 # one may find in a headless CI environment.
@@ -311,6 +319,82 @@ role of the `sts:AssumeRoleWithWebIdentity` action type. This setting is on the
 trust relationship tab when viewing a specific role in the AWS Console. Also
 note the ARNs of these roles for later use.
 
+## Direct Command
+
+**NOTE**: The `direct` command only operates with an Okta OIDC app, not the
+Okta AWS Federation app.
+
+```shell
+# use the shell to read in username/password, both can be set directly as CLI
+# flags for the headless use case
+
+# zsh style
+# read "myusername?Okta Username: " && read -s "mypassword?Okta Password: " && echo 
+
+# bash style
+$ read -p "Okta Username: " myusername && read -s -p "Okta Password: " mypassword && echo
+
+Okta Username: test@example.com
+Okta Password:
+
+$ okta-aws-cli direct \
+  --format noop \
+  --org-domain test.okta.com \
+  --oidc-client-id 0oa123 \
+  --authz-id aus456 \
+  --aws-iam-role arn:aws:iam::1234567890:role/my-role \
+  --username "${myusername}" \
+  --password "${mypassword}" \
+  --exec -- aws sts get-caller-identity
+
+{
+    "UserId": "ZYZ789:okta-aws-cli",
+    "Account": "1234567890",
+    "Arn": "arn:aws:sts::1234567890:assumed-role/my-role"
+}
+```
+
+The `direct` command makes use of the (direct
+authorization)[https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/]
+flow that uses a username/password grant. It is a multifactor authentication
+flow doing push to [Okta
+Verify](https://help.okta.com/en-us/content/topics/mobile/okta-verify-overview.htm)
+for the second factor. This will allow for a user experience similar to Nike
+Gimme Creds on a Classic classic org with a username and password.
+
+When executed `okta-aws-cli direct` requests an access token that is associated
+with the Okta service application. The token is then exchanged and challenged
+during the out-of-bounds authorization with a push to Okta Verify. After the
+operator acknowledges the request in Okta Verity the Okta authorization server
+returns a final access token. This token is presented to AWS STS using
+[AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).
+AWS and Okta communicate directly by OIDC protocol to confirm authorization for
+IAM credentials.
+
+Given access is granted by AWS the result of `okta-aws-cli direct` is a set
+made up of `Access Key ID`, `Secret Access Key`, and `Session Token` of [AWS
+credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+for the AWS CLI. The Okta AWS CLI expresses the AWS credentials as [environment
+variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html),
+or appended (or overwrites existing values) to an AWS CLI [credentials
+file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html),
+or emits JSON in [process
+credentials](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html)
+format.
+
+The `Session Token` has a default expiry of 60 minutes.
+
+### Direct Command Requirements
+
+Direct is an integration of:
+
+- Otka's [Direct Authorization](https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/), and out-of-bounds MFA flow
+- [Okta API service app](https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/main/)
+- Okta [custom](https://developer.okta.com/docs/guides/customize-authz-server/main/) authorization server
+- [Okta access policy](https://developer.okta.com/docs/guides/configure-access-policy/main/) associated with the service app and have rule(s) for the client credentials flow
+- [AWS IAM OpenID Connect (OIDC) identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
+
+
 ## List-Profiles Command
 
 ```shell
@@ -373,8 +457,8 @@ These global settings are optional unless marked otherwise:
 |-----|-----|-----|-----|
 | AWS Region (**optional**) | AWS region (will override ENV VAR `AWS_REGION` and `AWS_DEFAULT_REGION`) e.g. `us-east-2` | `--aws-region [value]` | `OKTA_AWSCLI_AWS_REGION` |
 | Okta Org Domain (**required**) | Full host and domain name of the Okta org e.g. `my-org.okta.com` or the custom domain value | `--org-domain [value]` | `OKTA_AWSCLI_ORG_DOMAIN` |
-| OIDC Client ID (**required**) | For `web` the OIDC native application / [Allowed Web SSO Client ID](#allowed-web-sso-client-id), for `m2m` the API services app ID | `--oidc-client-id [value]` | `OKTA_AWSCLI_OIDC_CLIENT_ID` |
-| AWS IAM Role ARN (**optional** for `web`, **required** for `m2m`) | For web preselects the role list to this preferred IAM role for the given IAM Identity Provider. For `m2m` | `--aws-iam-role [value]` | `OKTA_AWSCLI_IAM_ROLE` |
+| OIDC Client ID (**required**) | For `web` the OIDC native application / [Allowed Web SSO Client ID](#allowed-web-sso-client-id), for `m2m` and `direct` the API services app ID | `--oidc-client-id [value]` | `OKTA_AWSCLI_OIDC_CLIENT_ID` |
+| AWS IAM Role ARN (**optional** for `web`, **required** for `m2m` and `direct`) | For web preselects the role list to this preferred IAM role for the given IAM Identity Provider. For `m2m` and `direct` | `--aws-iam-role [value]` | `OKTA_AWSCLI_IAM_ROLE` |
 | AWS Session Duration | The lifetime, in seconds, of the AWS credentials. Must be between 60 and 43200. | `--aws-session-duration [value]` | `OKTA_AWSCLI_SESSION_DURATION` |
 | Output format | Default is `env-var`. Options: `env-var` for output to environment variables, `aws-credentials` for output to AWS credentials file, `process-credentials` for credentials as JSON, or `noop` for no output which can be useful with `--exec` | `--format [value]` | `OKTA_AWSCLI_FORMAT` |
 | Profile | Default is `default` | `--profile [value]` | `OKTA_AWSCLI_PROFILE` |
@@ -388,7 +472,6 @@ These global settings are optional unless marked otherwise:
 | HTTP/HTTPS Proxy support | HTTP/HTTPS URL of proxy service (based on golang [net/http/httpproxy](https://pkg.go.dev/golang.org/x/net/http/httpproxy) package) | n/a | `HTTP_PROXY` or `HTTPS_PROXY` |
 | Execute arguments after CLI arg terminator `--` as a separate process. Process will be executed with AWS cred values as AWS env vars `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`. | `true` if flag is present | `--exec` | `OKTA_AWSCLI_EXEC=true` |
 | Short user agent. HTTP requests made to the Okta API have user-agent set to `okta-aws-cli` allowing for a simple UA value in a policy rule. | `true` if flag is present | `--short-user-agent` | `OKTA_AWSCLI_SHORT_USER_AGENT=true` |
-
 
 
 ### Web command settings
@@ -472,6 +555,17 @@ These settings are optional unless marked otherwise:
 | Private Key File (**required** in lieu of private key) | File holding PEM (pkcs#1 or pkcs#9) private key whose public key is stored on the service app | `--private-key-file [value]` | `OKTA_AWSCLI_PRIVATE_KEY_FILE` |
 | Authorization Server ID | The ID of the Okta authorization server, set ID for a custom authorization server, will use default otherwise. Default `default` | `--authz-id [value]` | `OKTA_AWSCLI_AUTHZ_ID` |
 | Custom scope name | The custom scope established in the custom authorization server. Default `okta-m2m-access` | `--custom-scope [value]` | `OKTA_AWSCLI_CUSTOM_SCOPE` |
+| Custom STS Role Session Name | Customize STS Role Session Name. Default `okta-aws-cli` | `--aws-sts-role-session-name [value]` | `OKTA_AWSCLI_STS_ROLE_SESSION_NAME` |
+
+### Direct command settings
+
+These settings are optional unless marked otherwise:
+
+| Name | Description | Command line flag | ENV var and .env file value |
+|-----|-----|-----|-----|
+| Username (**required**) | The username of the operator | `--username [value]` | `OKTA_AWSCLI_USERNAME` |
+| Password (**required**) | The password of the operator | `--password [value]` | `OKTA_AWSCLI_PASSWORD` |
+| Authorization Server ID | The ID of the Okta authorization server, set ID for a custom authorization server, will use default otherwise. Default `default` | `--authz-id [value]` | `OKTA_AWSCLI_AUTHZ_ID` |
 | Custom STS Role Session Name | Customize STS Role Session Name. Default `okta-aws-cli` | `--aws-sts-role-session-name [value]` | `OKTA_AWSCLI_STS_ROLE_SESSION_NAME` |
 
 ### Friendly IdP and Role menu labels

--- a/cmd/root/direct/direct.go
+++ b/cmd/root/direct/direct.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package direct
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/okta/okta-aws-cli/internal/directauth"
+	cliFlag "github.com/okta/okta-aws-cli/internal/flag"
+)
+
+var (
+	flags = []cliFlag.Flag{
+		{
+			Name:   config.UsernameFlag,
+			Short:  "a",
+			Value:  "",
+			Usage:  "Username",
+			EnvVar: config.UsernameEnvVar,
+		},
+		{
+			Name:   config.PasswordFlag,
+			Short:  "b",
+			Value:  "",
+			Usage:  "Password",
+			EnvVar: config.PasswordEnvVar,
+		},
+		{
+			Name:   config.AuthzIDFlag,
+			Short:  "u",
+			Value:  "",
+			Usage:  "Custom Authorization Server ID",
+			EnvVar: config.AuthzIDEnvVar,
+		},
+		{
+			Name:   config.AWSSTSRoleSessionNameFlag,
+			Short:  "q",
+			Value:  "okta-aws-cli",
+			Usage:  "STS Role Session Name",
+			EnvVar: config.AWSSTSRoleSessionNameEnvVar,
+		},
+	}
+	requiredFlags = []interface{}{"org-domain", "oidc-client-id", "aws-iam-role", []string{"username", "password"}}
+)
+
+// NewDirectCommand Sets up the direct cobra sub command
+func NewDirectCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "direct",
+		Short: "Direct authorization with multifactor out-of-band flow",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := config.NewEvaluatedConfig()
+			if err != nil {
+				return err
+			}
+
+			err = cliFlag.CheckRequiredFlags(requiredFlags)
+			if err != nil {
+				return err
+			}
+
+			da, err := directauth.NewDirectAuthentication(config)
+			if err != nil {
+				return err
+			}
+			return da.EstablishIAMCredentials()
+		},
+	}
+
+	cliFlag.MakeFlagBindings(cmd, flags, false)
+
+	return cmd
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	debugCmd "github.com/okta/okta-aws-cli/cmd/root/debug"
+	"github.com/okta/okta-aws-cli/cmd/root/direct"
 	"github.com/okta/okta-aws-cli/cmd/root/m2m"
 	"github.com/okta/okta-aws-cli/cmd/root/web"
 	"github.com/okta/okta-aws-cli/internal/ansi"
@@ -171,6 +172,8 @@ func init() {
 	rootCmd.AddCommand(webCmd)
 	m2mCmd := m2m.NewM2MCommand()
 	rootCmd.AddCommand(m2mCmd)
+	directCmd := direct.NewDirectCommand()
+	rootCmd.AddCommand(directCmd)
 	debugCfgCmd := debugCmd.NewDebugCommand()
 	rootCmd.AddCommand(debugCfgCmd)
 	listProfilesCmd := profileslist.NewProfilesListCommand()

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -94,7 +94,8 @@ func (c *ProcessCredential) MarshalJSON() ([]byte, error) {
 	return json.Marshal(obj)
 }
 
-func AWSAssumeRoleWithWebIdentity(cfg *config.Config, at *okta.AccessToken) (cc *CredentialContainer, err error) {
+// AssumeRoleWithWebIdentity helper function to make the assume role with web identity AWS API call
+func AssumeRoleWithWebIdentity(cfg *config.Config, at *okta.AccessToken) (cc *CredentialContainer, err error) {
 	awsCfg := aws.NewConfig().WithHTTPClient(cfg.HTTPClient())
 	region := cfg.AWSRegion()
 	if region != "" {

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -19,6 +19,12 @@ package aws
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/okta/okta-aws-cli/internal/okta"
 )
 
 // CredentialContainer denormalized struct of all the values can be presented in
@@ -86,4 +92,37 @@ func (c *ProcessCredential) MarshalJSON() ([]byte, error) {
 		obj.Expiration = exp
 	}
 	return json.Marshal(obj)
+}
+
+func AWSAssumeRoleWithWebIdentity(cfg *config.Config, at *okta.AccessToken) (cc *CredentialContainer, err error) {
+	awsCfg := aws.NewConfig().WithHTTPClient(cfg.HTTPClient())
+	region := cfg.AWSRegion()
+	if region != "" {
+		awsCfg = awsCfg.WithRegion(region)
+	}
+	sess, err := session.NewSession(awsCfg)
+	if err != nil {
+		return
+	}
+
+	svc := sts.New(sess)
+	input := &sts.AssumeRoleWithWebIdentityInput{
+		DurationSeconds:  aws.Int64(cfg.AWSSessionDuration()),
+		RoleArn:          aws.String(cfg.AWSIAMRole()),
+		RoleSessionName:  aws.String(cfg.AWSSTSRoleSessionName()),
+		WebIdentityToken: &at.AccessToken,
+	}
+	svcResp, err := svc.AssumeRoleWithWebIdentity(input)
+	if err != nil {
+		return
+	}
+
+	cc = &CredentialContainer{
+		AccessKeyID:     *svcResp.Credentials.AccessKeyId,
+		SecretAccessKey: *svcResp.Credentials.SecretAccessKey,
+		SessionToken:    *svcResp.Credentials.SessionToken,
+		Expiration:      svcResp.Credentials.Expiration,
+	}
+
+	return cc, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ func init() {
 
 const (
 	// Version app version
-	Version = "2.4.1"
+	Version = "2.5.0"
 
 	////////////////////////////////////////////////////////////
 	// FORMATS

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,11 @@ const (
 	// CacheAccessTokenFlag cli flag const
 	CacheAccessTokenFlag = "cache-access-token"
 
+	// UsernameFlag cli flag const
+	UsernameFlag = "username"
+	// PasswordFlag cli flag const
+	PasswordFlag = "password"
+
 	////////////////////////////////////////////////////////////
 	// ENV VARS
 	////////////////////////////////////////////////////////////
@@ -192,6 +197,11 @@ const (
 	// WriteAWSCredentialsEnvVar env var const
 	WriteAWSCredentialsEnvVar = "OKTA_AWSCLI_WRITE_AWS_CREDENTIALS"
 
+	// UsernameEnvVar env var const
+	UsernameEnvVar = "OKTA_AWSCLI_USERNAME"
+	// PasswordEnvVar env var const
+	PasswordEnvVar = "OKTA_AWSCLI_PASSWORD"
+
 	////////////////////////////////////////////////////////////
 	// Other
 	////////////////////////////////////////////////////////////
@@ -248,6 +258,8 @@ type OktaYamlConfigProfile struct {
 	LegacyAWSVariables    string `yaml:"legacy-aws-variables"`
 	ExpiryAWSVariables    string `yaml:"expiry-aws-variables"`
 	CacheAccessToken      string `yaml:"cache-access-token"`
+	Username              string `yaml:"username"`
+	Password              string `yaml:"password"`
 }
 
 // Clock interface to abstract time operations
@@ -291,6 +303,8 @@ type Config struct {
 	qrCode                bool
 	shortUserAgent        bool
 	writeAWSCredentials   bool
+	username              string
+	password              string
 	clock                 Clock
 	Logger                logger.Logger
 }
@@ -325,6 +339,8 @@ type Attributes struct {
 	QRCode                bool
 	ShortUserAgent        bool
 	WriteAWSCredentials   bool
+	Username              string
+	Password              string
 }
 
 // NewEvaluatedConfig Returns a new config loading and evaluating attributes in
@@ -383,6 +399,8 @@ func NewConfig(attrs *Attributes) (*Config, error) {
 		qrCode:                attrs.QRCode,
 		shortUserAgent:        attrs.ShortUserAgent,
 		writeAWSCredentials:   attrs.WriteAWSCredentials,
+		username:              attrs.Username,
+		password:              attrs.Password,
 	}
 	err = cfg.SetOrgDomain(attrs.OrgDomain)
 	if err != nil {
@@ -501,6 +519,8 @@ func loadConfigAttributesFromFlagsAndVars() (Attributes, error) {
 		QRCode:                viper.GetBool(getFlagNameFromProfile(awsProfile, QRCodeFlag)),
 		ShortUserAgent:        viper.GetBool(getFlagNameFromProfile(awsProfile, ShortUserAgentFlag)),
 		WriteAWSCredentials:   viper.GetBool(getFlagNameFromProfile(awsProfile, WriteAWSCredentialsFlag)),
+		Username:              viper.GetString(getFlagNameFromProfile(awsProfile, UsernameFlag)),
+		Password:              viper.GetString(getFlagNameFromProfile(awsProfile, PasswordFlag)),
 	}
 	if attrs.Format == "" {
 		attrs.Format = EnvVarFormat
@@ -559,6 +579,12 @@ func loadConfigAttributesFromFlagsAndVars() (Attributes, error) {
 	}
 	if attrs.AWSRegion == "" {
 		attrs.AWSRegion = viper.GetString(downCase(AWSRegionEnvVar))
+	}
+	if attrs.Username == "" {
+		attrs.Username = viper.GetString(downCase(UsernameEnvVar))
+	}
+	if attrs.Password == "" {
+		attrs.Password = viper.GetString(downCase(PasswordEnvVar))
 	}
 
 	// if session duration is 0, check DEPRECATED session duration flag
@@ -947,6 +973,28 @@ func (c *Config) KeyID() string {
 // SetKeyID --
 func (c *Config) SetKeyID(keyID string) error {
 	c.keyID = keyID
+	return nil
+}
+
+// Username --
+func (c *Config) Username() string {
+	return c.username
+}
+
+// SetUsername --
+func (c *Config) SetUsername(username string) error {
+	c.username = username
+	return nil
+}
+
+// Password --
+func (c *Config) Password() string {
+	return c.password
+}
+
+// SetPassword --
+func (c *Config) SetPassword(password string) error {
+	c.password = password
 	return nil
 }
 

--- a/internal/directauth/directauth.go
+++ b/internal/directauth/directauth.go
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2025-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package directauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	oaws "github.com/okta/okta-aws-cli/internal/aws"
+	boff "github.com/okta/okta-aws-cli/internal/backoff"
+	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/okta/okta-aws-cli/internal/exec"
+	"github.com/okta/okta-aws-cli/internal/okta"
+	"github.com/okta/okta-aws-cli/internal/output"
+	"github.com/okta/okta-aws-cli/internal/utils"
+)
+
+// DirectAuthentication Object structure for headless authentication
+type DirectAuthentication struct {
+	config *config.Config
+}
+
+// NewDirectAuthentication New Direct Authentication constructor
+func NewDirectAuthentication(cfg *config.Config) (*DirectAuthentication, error) {
+	// need to set our config defaults
+	if cfg.AuthzID() == "" {
+		_ = cfg.SetAuthzID(utils.DefaultAuthzID)
+	}
+
+	// Check if exec arg is present and that there are args for it before doing any work
+	if cfg.Exec() {
+		if _, err := exec.NewExec(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	da := DirectAuthentication{
+		config: cfg,
+	}
+	return &da, nil
+}
+
+// EstablishIAMCredentials Full operation to fetch temporary IAM credentials and
+// output them to preferred format.
+//
+// The overall API interactions are as follows:
+//
+// - CLI requests access token from custom authz server at /oauth2/{authzID}/v1/token
+// - CLI triggers challenge to be pushed to Okta Verify over custom authz server at /oauth2/{authzID}/v1/challenge
+// - CLI polls custom authz server at /oauth2/{authzID}/v1/token waiting for Okta Verify push to be acknowledged
+// - CLI presents access token to AWS STS for temporary AWS IAM creds
+func (da *DirectAuthentication) EstablishIAMCredentials() error {
+	var at *okta.AccessToken
+	var err error
+	at = utils.CachedAccessToken(da.config)
+	if at == nil {
+		mfaToken, err := da.requestMFAToken()
+		if err != nil {
+			return err
+		}
+
+		at, err = da.challengeAndPollForAT(mfaToken)
+		if err != nil {
+			return err
+		}
+		at.Expiry = time.Now().Add(time.Duration(at.ExpiresIn) * time.Second).Format(time.RFC3339)
+
+		utils.CacheAccessToken(da.config, at)
+	}
+
+	cc, err := oaws.AWSAssumeRoleWithWebIdentity(da.config, at)
+	if err != nil {
+		return fmt.Errorf("AWS Assume Role With Web Identity error %w", err)
+	}
+
+	err = output.RenderAWSCredential(da.config, cc)
+	if err != nil {
+		return err
+	}
+
+	if da.config.Exec() {
+		exe, _ := exec.NewExec(da.config)
+		if err := exe.Run(cc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// challengeAndPollForAT Isses a challenge request and then polls for Okta Verify result
+// https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/#challenge-request
+func (da *DirectAuthentication) challengeAndPollForAT(mfaToken *okta.MFAToken) (at *okta.AccessToken, err error) {
+	clientID := da.config.OIDCAppID()
+	challengeURL := fmt.Sprintf(okta.CustomAuthzV1ChallengeEndpointFormat, da.config.OrgDomain(), da.config.AuthzID())
+	data := url.Values{
+		"client_id":                 {clientID},
+		"mfa_token":                 {mfaToken.Token},
+		"challenge_types_supported": {"http://auth0.com/oauth/grant-type/mfa-oob"},
+		"channel_hint":              {"push"},
+	}
+	body := strings.NewReader(data.Encode())
+	req, err := http.NewRequest(http.MethodPost, challengeURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(utils.Accept, utils.ApplicationJSON)
+	req.Header.Add(utils.ContentType, utils.ApplicationXFORM)
+	req.Header.Add(utils.UserAgentHeader, da.config.UserAgent())
+	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
+	resp, err := da.config.HTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	// https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/#challenge-response
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("requesting OOB MFA token received response %q", resp.Status)
+	}
+
+	ct := resp.Header.Get(utils.ContentType)
+	if !strings.Contains(ct, utils.ApplicationJSON) {
+		return nil, fmt.Errorf("challenge response incorrect content type %q", ct)
+	}
+
+	var challengeToken okta.ChallengeToken
+	err = json.NewDecoder(resp.Body).Decode(&challengeToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var bodyBytes []byte
+
+	// Keep polling if Status Code is 400 and apiError.Error ==
+	// "authorization_pending". Done if status code is 200. Else error.
+	poll := func() error {
+		requestTokenURL := fmt.Sprintf(okta.CustomAuthzV1TokenEndpointFormat, da.config.OrgDomain(), da.config.AuthzID())
+		data := url.Values{
+			"client_id":  {clientID},
+			"scope":      {"openid profile"},
+			"grant_type": {"http://auth0.com/oauth/grant-type/mfa-oob"},
+			"oob_code":   {challengeToken.OOBCode},
+			"mfa_token":  {mfaToken.Token},
+		}
+		req, err := http.NewRequest(http.MethodPost, requestTokenURL, body)
+		if err != nil {
+			return err
+		}
+		body := strings.NewReader(data.Encode())
+		req.Body = io.NopCloser(body)
+		req.Header.Add(utils.Accept, utils.ApplicationJSON)
+		req.Header.Add(utils.ContentType, utils.ApplicationXFORM)
+		req.Header.Add(utils.UserAgentHeader, da.config.UserAgent())
+		req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
+
+		resp, err := da.config.HTTPClient().Do(req)
+		bodyBytes, _ = io.ReadAll(resp.Body)
+		if err != nil {
+			return backoff.Permanent(fmt.Errorf("fetching access token polling received API err %w", err))
+		}
+		if resp.StatusCode == http.StatusOK {
+			// done
+			return nil
+		}
+		if resp.StatusCode == http.StatusBadRequest {
+			// continue polling if status code is 400 and "error" is "authorization_pending"
+			apiErr, err := okta.APIErr(bodyBytes)
+			if err != nil {
+				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API error body %q", string(bodyBytes)))
+			}
+			if apiErr.ErrorType != "authorization_pending" && apiErr.ErrorType != "slow_down" {
+				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API polling error %q - %q", apiErr.ErrorType, apiErr.ErrorDescription))
+			}
+
+			return errors.New("continue polling")
+		}
+
+		return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API status %q %q", resp.Status, string(bodyBytes)))
+	}
+
+	bOff := boff.NewBackoff(context.Background())
+	err = backoff.Retry(poll, bOff)
+	if err != nil {
+		return nil, err
+	}
+
+	at = &okta.AccessToken{}
+	err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(at)
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+// requestMFAToken The start of the direct auth OOB MFA flow starts with requesting
+// the beginning access token.
+// https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/
+func (da *DirectAuthentication) requestMFAToken() (*okta.MFAToken, error) {
+	clientID := da.config.OIDCAppID()
+	username := da.config.Username()
+	password := da.config.Password()
+	requestTokenURL := fmt.Sprintf(okta.CustomAuthzV1TokenEndpointFormat, da.config.OrgDomain(), da.config.AuthzID())
+	data := url.Values{
+		"client_id":  {clientID},
+		"grant_type": {"password"},
+		"scope":      {"openid profile"},
+		"username":   {username},
+		"password":   {password},
+	}
+	body := strings.NewReader(data.Encode())
+	req, err := http.NewRequest(http.MethodPost, requestTokenURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(utils.Accept, utils.ApplicationJSON)
+	req.Header.Add(utils.ContentType, utils.ApplicationXFORM)
+	req.Header.Add(utils.UserAgentHeader, da.config.UserAgent())
+	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIDirectOperation)
+
+	resp, err := da.config.HTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	// we are in fact expecting a 403
+	// https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/#okta-token-response
+	if resp.StatusCode != http.StatusForbidden {
+		return nil, fmt.Errorf("requesting OOB MFA token received response %q", resp.Status)
+	}
+
+	ct := resp.Header.Get(utils.ContentType)
+	if !strings.Contains(ct, utils.ApplicationJSON) {
+		return nil, fmt.Errorf("authorize non-JSON API response content type %q", ct)
+	}
+
+	var mfaToken okta.MFAToken
+	err = json.NewDecoder(resp.Body).Decode(&mfaToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mfaToken, nil
+}

--- a/internal/m2mauth/m2mauth.go
+++ b/internal/m2mauth/m2mauth.go
@@ -89,7 +89,7 @@ func (m *M2MAuthentication) EstablishIAMCredentials() error {
 		return err
 	}
 
-	cc, err := oaws.AWSAssumeRoleWithWebIdentity(m.config, at)
+	cc, err := oaws.AssumeRoleWithWebIdentity(m.config, at)
 	if err != nil {
 		return err
 	}

--- a/internal/m2mauth/m2mauth.go
+++ b/internal/m2mauth/m2mauth.go
@@ -30,9 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
@@ -92,7 +89,7 @@ func (m *M2MAuthentication) EstablishIAMCredentials() error {
 		return err
 	}
 
-	cc, err := m.awsAssumeRoleWithWebIdentity(at)
+	cc, err := oaws.AWSAssumeRoleWithWebIdentity(m.config, at)
 	if err != nil {
 		return err
 	}
@@ -110,39 +107,6 @@ func (m *M2MAuthentication) EstablishIAMCredentials() error {
 	}
 
 	return nil
-}
-
-func (m *M2MAuthentication) awsAssumeRoleWithWebIdentity(at *okta.AccessToken) (cc *oaws.CredentialContainer, err error) {
-	awsCfg := aws.NewConfig().WithHTTPClient(m.config.HTTPClient())
-	region := m.config.AWSRegion()
-	if region != "" {
-		awsCfg = awsCfg.WithRegion(region)
-	}
-	sess, err := session.NewSession(awsCfg)
-	if err != nil {
-		return
-	}
-
-	svc := sts.New(sess)
-	input := &sts.AssumeRoleWithWebIdentityInput{
-		DurationSeconds:  aws.Int64(m.config.AWSSessionDuration()),
-		RoleArn:          aws.String(m.config.AWSIAMRole()),
-		RoleSessionName:  aws.String(m.config.AWSSTSRoleSessionName()),
-		WebIdentityToken: &at.AccessToken,
-	}
-	svcResp, err := svc.AssumeRoleWithWebIdentity(input)
-	if err != nil {
-		return
-	}
-
-	cc = &oaws.CredentialContainer{
-		AccessKeyID:     *svcResp.Credentials.AccessKeyId,
-		SecretAccessKey: *svcResp.Credentials.SecretAccessKey,
-		SessionToken:    *svcResp.Credentials.SessionToken,
-		Expiration:      svcResp.Credentials.Expiration,
-	}
-
-	return cc, nil
 }
 
 func (m *M2MAuthentication) createKeySigner() (jose.Signer, error) {

--- a/internal/okta/apierror.go
+++ b/internal/okta/apierror.go
@@ -36,6 +36,11 @@ const (
 	APIErrorMessageWithErrorSummary = "Okta API returned an error: %s"
 	// HTTPHeaderWwwAuthenticate Www-Authenticate header
 	HTTPHeaderWwwAuthenticate = "Www-Authenticate"
+
+	// AuthorizationPendingErrorType --
+	AuthorizationPendingErrorType = "authorization_pending"
+	// SlowDownErrorType --
+	SlowDownErrorType = "slow_down"
 )
 
 // APIError Wrapper for Okta API error
@@ -101,6 +106,7 @@ func NewAPIError(resp *http.Response) error {
 	return &e
 }
 
+// APIErr helper function to create and APIError pointer from a slice of bytes
 func APIErr(bodyBytes []byte) (ae *APIError, err error) {
 	ae = &APIError{}
 	err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(ae)

--- a/internal/okta/apierror.go
+++ b/internal/okta/apierror.go
@@ -100,3 +100,9 @@ func NewAPIError(resp *http.Response) error {
 	}
 	return &e
 }
+
+func APIErr(bodyBytes []byte) (ae *APIError, err error) {
+	ae = &APIError{}
+	err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(ae)
+	return
+}

--- a/internal/okta/challenge_token.go
+++ b/internal/okta/challenge_token.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okta
+
+// ChallengeToken Encapsulates Okta API response for the OOB MFA Challenge
+// Response Token from /oauth2/{authzID}/v1/challenge
+// https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/#challenge-response
+type ChallengeToken struct {
+	ChallengeType string `json:"challenge_type"`
+	OOBCode       string `json:"oob_code"`
+	ExpiresIn     int    `json:"expires_in"`
+	Interval      int    `json:"interval"`
+	Channel       string `json:"push"`
+	BindingMethod string `json:"binding_method"`
+	BindingCode   string `json:"binding_code"`
+}

--- a/internal/okta/messages.go
+++ b/internal/okta/messages.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okta
+
+const (
+	// PollingFetchAccessTokenAPIErrorMessage --
+	PollingFetchAccessTokenAPIErrorMessage = "fetching access token polling received API err %w"
+	// PollingFetchAccessTokenAPIErrorBodyMessage --
+	PollingFetchAccessTokenAPIErrorBodyMessage = "fetching access token polling received unexpected API error body %q"
+	// PollingFetchAccessTokenAPIErrorPollingMessage --
+	PollingFetchAccessTokenAPIErrorPollingMessage = "fetching access token polling received unexpected API polling error %q - %q"
+	// PollingFetchAccessTokenAPIErrorStatusMessage --
+	PollingFetchAccessTokenAPIErrorStatusMessage = "fetching access token polling received unexpected API status %q %q"
+	// NonJSONContentTypeErrorMessage --
+	NonJSONContentTypeErrorMessage = "authorize non-JSON API response content type %q"
+	// ContinuePollingMessage --
+	ContinuePollingMessage = "continue polling"
+)

--- a/internal/okta/mfa_token.go
+++ b/internal/okta/mfa_token.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package okta
+
+// MFAToken Encapsulates Okta API response for the OOB MFA Token at
+// /oauth2/{authzID}/v1/token
+type MFAToken struct {
+	ErrorType        string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	Token            string `json:"mfa_token"`
+}

--- a/internal/okta/okta.go
+++ b/internal/okta/okta.go
@@ -22,4 +22,7 @@ const (
 
 	// CustomAuthzV1TokenEndpointFormat sprintf format string for custom oauth server token endpoint
 	CustomAuthzV1TokenEndpointFormat = "https://%s/oauth2/%s/v1/token"
+
+	// CustomAuthzV1ChallengeEndpointFormat sprintf format string for custom oauth server token endpoint
+	CustomAuthzV1ChallengeEndpointFormat = "https://%s/oauth2/%s/v1/challenge"
 )

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -37,6 +37,8 @@ const (
 	UserAgentHeader = "User-Agent"
 	// XOktaAWSCLIOperationHeader the okta aws cli header
 	XOktaAWSCLIOperationHeader = "X-Okta-Aws-Cli-Operation"
+	// XOktaAWSCLIDirectOperation direct op value for the x okta aws cli header
+	XOktaAWSCLIDirectOperation = "direct"
 	// XOktaAWSCLIWebOperation web op value for the x okta aws cli header
 	XOktaAWSCLIWebOperation = "web"
 	// XOktaAWSCLIM2MOperation m2m op value for the x okta aws cli header

--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -28,7 +28,6 @@ import (
 	"net/url"
 	"os"
 	osexec "os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -60,7 +59,6 @@ import (
 
 const (
 	amazonAWS                = "amazon_aws"
-	accept                   = "Accept"
 	nameKey                  = "name"
 	saml2Attribute           = "saml2:attribute"
 	samlAttributesRole       = "https://aws.amazon.com/SAML/Attributes/Role"
@@ -74,8 +72,6 @@ const (
 	chooseRole               = "Choose a Role:"
 	idpSelectedTemplate      = `  {{color "default+hb"}}IdP: {{color "reset"}}{{color "cyan"}}{{ .IDP }}{{color "reset"}}`
 	roleSelectedTemplate     = `  {{color "default+hb"}}Role: {{color "reset"}}{{color "cyan"}}{{ .Role }}{{color "reset"}}`
-	dotOktaDir               = ".okta"
-	tokenFileName            = "awscli-access-token.json"
 	arnLabelPrintFmt         = "      %q: %q\n"
 	arnPrintFmt              = "    %q\n"
 )
@@ -150,7 +146,7 @@ func (w *WebSSOAuthentication) EstablishIAMCredentials() error {
 	var apps []*okta.Application
 	var err error
 
-	at = w.cachedAccessToken()
+	at = utils.CachedAccessToken(w.config)
 	if at == nil {
 		deviceAuth, err := w.authorize()
 		if err != nil {
@@ -164,7 +160,7 @@ func (w *WebSSOAuthentication) EstablishIAMCredentials() error {
 		}
 		at.Expiry = time.Now().Add(time.Duration(at.ExpiresIn) * time.Second).Format(time.RFC3339)
 
-		w.cacheAccessToken(at)
+		utils.CacheAccessToken(w.config, at)
 	}
 
 	if w.config.FedAppID() != "" {
@@ -651,7 +647,7 @@ func (w *WebSSOAuthentication) fetchSAMLAssertion(at *okta.AccessToken) (asserti
 	if err != nil {
 		return assertion, err
 	}
-	req.Header.Add(accept, "text/html")
+	req.Header.Add(utils.Accept, "text/html")
 	req.Header.Add(utils.UserAgentHeader, w.config.UserAgent())
 	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
 
@@ -693,7 +689,7 @@ func (w *WebSSOAuthentication) fetchSSOWebToken(clientID, awsFedAppID string, at
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(accept, utils.ApplicationJSON)
+	req.Header.Add(utils.Accept, utils.ApplicationJSON)
 	req.Header.Add(utils.ContentType, utils.ApplicationXFORM)
 	req.Header.Add(utils.UserAgentHeader, w.config.UserAgent())
 	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
@@ -775,7 +771,7 @@ func (w *WebSSOAuthentication) promptAuthentication(da *okta.DeviceAuthorization
 // okta.users.read.self to its scope.
 func (w *WebSSOAuthentication) listFedAppsFromAppLinks(clientID string, at *okta.AccessToken) ([]*okta.Application, error) {
 	headers := map[string]string{
-		accept:                           utils.ApplicationJSON,
+		utils.Accept:                     utils.ApplicationJSON,
 		utils.ContentType:                utils.ApplicationJSON,
 		utils.UserAgentHeader:            w.config.UserAgent(),
 		utils.XOktaAWSCLIOperationHeader: utils.XOktaAWSCLIWebOperation,
@@ -822,7 +818,7 @@ func (w *WebSSOAuthentication) accessToken(deviceAuth *okta.DeviceAuthorization)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(accept, utils.ApplicationJSON)
+	req.Header.Add(utils.Accept, utils.ApplicationJSON)
 	req.Header.Add(utils.ContentType, utils.ApplicationXFORM)
 	req.Header.Add(utils.UserAgentHeader, w.config.UserAgent())
 	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
@@ -851,7 +847,7 @@ func (w *WebSSOAuthentication) accessToken(deviceAuth *okta.DeviceAuthorization)
 		}
 		if resp.StatusCode == http.StatusBadRequest {
 			// continue polling if status code is 400 and "error" is "authorization_pending"
-			apiErr, err := apiErr(bodyBytes)
+			apiErr, err := okta.APIErr(bodyBytes)
 			if err != nil {
 				return backoff.Permanent(fmt.Errorf("fetching access token polling received unexpected API error body %q", string(bodyBytes)))
 			}
@@ -894,7 +890,7 @@ func (w *WebSSOAuthentication) authorize() (*okta.DeviceAuthorization, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(accept, utils.ApplicationJSON)
+	req.Header.Add(utils.Accept, utils.ApplicationJSON)
 	req.Header.Add(utils.ContentType, utils.ApplicationXFORM)
 	req.Header.Add(utils.UserAgentHeader, w.config.UserAgent())
 	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
@@ -980,12 +976,6 @@ func findSAMLRoleAttibute(n *html.Node) (node *html.Node, found bool) {
 	return nil, false
 }
 
-func apiErr(bodyBytes []byte) (ae *okta.APIError, err error) {
-	ae = &okta.APIError{}
-	err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(ae)
-	return
-}
-
 // ClassicOrgError Convenience error class.
 type ClassicOrgError struct {
 	orgDomain string
@@ -1009,7 +999,7 @@ func (w *WebSSOAuthentication) isClassicOrg() bool {
 	if err != nil {
 		return false
 	}
-	req.Header.Add(accept, utils.ApplicationJSON)
+	req.Header.Add(utils.Accept, utils.ApplicationJSON)
 	req.Header.Add(utils.UserAgentHeader, w.config.UserAgent())
 	req.Header.Add(utils.XOktaAWSCLIOperationHeader, utils.XOktaAWSCLIWebOperation)
 
@@ -1034,19 +1024,10 @@ func (w *WebSSOAuthentication) isClassicOrg() bool {
 	return false
 }
 
-// cachedAccessTokenPath Path to the cached access token in $HOME/.okta/awscli-access-token.json
-func cachedAccessTokenPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, dotOktaDir, tokenFileName), nil
-}
-
 // RemoveCachedAccessToken Remove cached access token if it exists. Returns true
 // if the file exists was reremoved, swallows errors otherwise.
 func RemoveCachedAccessToken() bool {
-	accessTokenPath, err := cachedAccessTokenPath()
+	accessTokenPath, err := utils.CachedAccessTokenPath()
 	if err != nil {
 		return false
 	}
@@ -1055,68 +1036,6 @@ func RemoveCachedAccessToken() bool {
 	}
 
 	return true
-}
-
-// cachedAccessToken will returned the cached access token if it exists and is
-// not expired and --cached-access-token is enabled.
-func (w *WebSSOAuthentication) cachedAccessToken() (at *okta.AccessToken) {
-	if !w.config.CacheAccessToken() {
-		return
-	}
-
-	accessTokenPath, err := cachedAccessTokenPath()
-	if err != nil {
-		return
-	}
-	atJSON, err := os.ReadFile(accessTokenPath)
-	if err != nil {
-		return
-	}
-
-	_at := okta.AccessToken{}
-	err = json.Unmarshal(atJSON, &_at)
-	if err != nil {
-		return
-	}
-
-	expiry, err := time.Parse(time.RFC3339, _at.Expiry)
-	if err != nil {
-		return
-	}
-	if expiry.Before(time.Now()) {
-		// expiry is in the past
-		return
-	}
-
-	return &_at
-}
-
-// cacheAccessToken will cache the access token for later use if enabled. Silent
-// if fails.
-func (w *WebSSOAuthentication) cacheAccessToken(at *okta.AccessToken) {
-	if !w.config.CacheAccessToken() {
-		return
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return
-	}
-
-	oktaDir := filepath.Join(homeDir, dotOktaDir)
-	// noop if dir exists
-	err = os.MkdirAll(oktaDir, 0o700)
-	if err != nil {
-		return
-	}
-
-	atJSON, err := json.Marshal(at)
-	if err != nil {
-		return
-	}
-
-	configPath := filepath.Join(homeDir, dotOktaDir, tokenFileName)
-	_ = os.WriteFile(configPath, atJSON, 0o600)
 }
 
 // ConsolePrint printf formatted warning messages.


### PR DESCRIPTION
New `direct` command that implements out-of-bounds MFA [(Direct Authentication)](https://developer.okta.com/docs/guides/configure-direct-auth-grants/dmfaoobov/main/). OOB MFA combines the username/password grant with a push to Okta Verify for the second factor.

```shell
# use the shell to read in username/password, both can be set directly as CLI
# flags for the headless use case

# zsh style
# read "myusername?Okta Username: " && read -s "mypassword?Okta Password: " && echo

# bash style
$ read -p "Okta Username: " myusername && read -s -p "Okta Password: " mypassword && echo

Okta Username: test@example.com
Okta Password:

$ okta-aws-cli direct \
  --format noop \
  --org-domain test.okta.com \
  --oidc-client-id 0oa123 \
  --authz-id aus456 \
  --aws-iam-role arn:aws:iam::1234567890:role/my-role \
  --username "${myusername}" \
  --password "${mypassword}" \
  --exec -- aws sts get-caller-identity

{
    "UserId": "ZYZ789:okta-aws-cli",
    "Account": "1234567890",
    "Arn": "arn:aws:sts::1234567890:assumed-role/my-role"
}
```