### PR TITLE
Adds support for short-user-agent via okta.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ awscli:
       aws-iam-role: "arn:aws:iam::123:role/S3_Read"
       write-aws-credentials: true
       open-browser: true
+      short-user-agent: true
     production:
       oidc-client-id: "0opabc"
       org-domain: "org-prd.okata.com"
@@ -664,6 +665,7 @@ awscli:
       aws-iam-role: "arn:aws:iam::456:role/S3_Read"
       write-aws-credentials: true
       open-browser: true
+      short-user-agent: false
 ```
 
 ## Debug okta.yaml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -258,6 +258,7 @@ type OktaYamlConfigProfile struct {
 	LegacyAWSVariables    string `yaml:"legacy-aws-variables"`
 	ExpiryAWSVariables    string `yaml:"expiry-aws-variables"`
 	CacheAccessToken      string `yaml:"cache-access-token"`
+	ShortUserAgent        string `yaml:"short-user-agent"`
 	Username              string `yaml:"username"`
 	Password              string `yaml:"password"`
 }


### PR DESCRIPTION
My org recently switched to using this tool and found that `short-user-agent` was not supported when set via `~/.okta/okta.yaml`. I believe this should fix that.