### PR TITLE
fix: use v2 imports for go package

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,20 @@ okta-aws-cli is distributed to Windows via [Chocolatey](https://community.chocol
 > choco install okta-aws-cli
 ```
 
+### Go Install
+
+If you have Go 1.21 or later installed, you can install okta-aws-cli directly using `go install`:
+
+```bash
+# Install the latest version
+go install github.com/okta/okta-aws-cli/v2@latest
+
+# Install a specific version
+go install github.com/okta/okta-aws-cli/v2@v2.5.1
+```
+
+This will install the `okta-aws-cli` binary to your `$GOPATH/bin` directory (typically `~/go/bin`). Make sure this directory is in your `PATH`.
+
 ### Local build/install
 
 See [Development](#development) section.

--- a/cmd/okta-aws-cli/main.go
+++ b/cmd/okta-aws-cli/main.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	"github.com/okta/okta-aws-cli/cmd/root"
+	"github.com/okta/okta-aws-cli/v2/cmd/root"
 )
 
 func main() {

--- a/cmd/root/debug/debug.go
+++ b/cmd/root/debug/debug.go
@@ -19,7 +19,7 @@ package debug
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
 )
 
 // NewDebugCommand Sets up the debug cobra sub command

--- a/cmd/root/direct/direct.go
+++ b/cmd/root/direct/direct.go
@@ -19,9 +19,9 @@ package direct
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/directauth"
-	cliFlag "github.com/okta/okta-aws-cli/internal/flag"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/directauth"
+	cliFlag "github.com/okta/okta-aws-cli/v2/internal/flag"
 )
 
 var (

--- a/cmd/root/m2m/m2m.go
+++ b/cmd/root/m2m/m2m.go
@@ -19,9 +19,9 @@ package m2m
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	cliFlag "github.com/okta/okta-aws-cli/internal/flag"
-	"github.com/okta/okta-aws-cli/internal/m2mauth"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	cliFlag "github.com/okta/okta-aws-cli/v2/internal/flag"
+	"github.com/okta/okta-aws-cli/v2/internal/m2mauth"
 )
 
 var (

--- a/cmd/root/profileslist/profiles-list.go
+++ b/cmd/root/profileslist/profiles-list.go
@@ -19,7 +19,7 @@ package profileslist
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/okta/okta-aws-cli/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
 )
 
 // NewProfilesListCommand Sets up the debug cobra sub command

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -21,17 +21,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/okta/okta-aws-cli/cmd/root/profileslist"
+	"github.com/okta/okta-aws-cli/v2/cmd/root/profileslist"
 
 	"github.com/spf13/cobra"
 
-	debugCmd "github.com/okta/okta-aws-cli/cmd/root/debug"
-	"github.com/okta/okta-aws-cli/cmd/root/direct"
-	"github.com/okta/okta-aws-cli/cmd/root/m2m"
-	"github.com/okta/okta-aws-cli/cmd/root/web"
-	"github.com/okta/okta-aws-cli/internal/ansi"
-	"github.com/okta/okta-aws-cli/internal/config"
-	cliFlag "github.com/okta/okta-aws-cli/internal/flag"
+	debugCmd "github.com/okta/okta-aws-cli/v2/cmd/root/debug"
+	"github.com/okta/okta-aws-cli/v2/cmd/root/direct"
+	"github.com/okta/okta-aws-cli/v2/cmd/root/m2m"
+	"github.com/okta/okta-aws-cli/v2/cmd/root/web"
+	"github.com/okta/okta-aws-cli/v2/internal/ansi"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	cliFlag "github.com/okta/okta-aws-cli/v2/internal/flag"
 )
 
 var (

--- a/cmd/root/web/web.go
+++ b/cmd/root/web/web.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	cliFlag "github.com/okta/okta-aws-cli/internal/flag"
-	"github.com/okta/okta-aws-cli/internal/okta"
-	"github.com/okta/okta-aws-cli/internal/webssoauth"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	cliFlag "github.com/okta/okta-aws-cli/v2/internal/flag"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/webssoauth"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/okta/okta-aws-cli
+module github.com/okta/okta-aws-cli/v2
 
 go 1.21
 

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -23,8 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
 )
 
 // CredentialContainer denormalized struct of all the values can be presented in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 
-	"github.com/okta/okta-aws-cli/internal/logger"
+	"github.com/okta/okta-aws-cli/v2/internal/logger"
 )
 
 // longUserAgent the long user agent value

--- a/internal/directauth/directauth.go
+++ b/internal/directauth/directauth.go
@@ -30,13 +30,13 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	boff "github.com/okta/okta-aws-cli/internal/backoff"
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/exec"
-	"github.com/okta/okta-aws-cli/internal/okta"
-	"github.com/okta/okta-aws-cli/internal/output"
-	"github.com/okta/okta-aws-cli/internal/utils"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	boff "github.com/okta/okta-aws-cli/v2/internal/backoff"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/exec"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/output"
+	"github.com/okta/okta-aws-cli/v2/internal/utils"
 )
 
 // DirectAuthentication Object structure for headless authentication

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -22,9 +22,9 @@ import (
 	osexec "os/exec"
 	"strings"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/utils"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/utils"
 )
 
 // Exec is a executor / a process runner

--- a/internal/m2mauth/m2mauth.go
+++ b/internal/m2mauth/m2mauth.go
@@ -33,12 +33,12 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/exec"
-	"github.com/okta/okta-aws-cli/internal/okta"
-	"github.com/okta/okta-aws-cli/internal/output"
-	"github.com/okta/okta-aws-cli/internal/utils"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/exec"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/output"
+	"github.com/okta/okta-aws-cli/v2/internal/utils"
 )
 
 const (

--- a/internal/m2mauth/m2mauth_test.go
+++ b/internal/m2mauth/m2mauth_test.go
@@ -22,8 +22,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/testutils"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/output/aws_credentials_file.go
+++ b/internal/output/aws_credentials_file.go
@@ -27,9 +27,9 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/ini.v1"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/utils"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/utils"
 )
 
 const (

--- a/internal/output/aws_credentials_file_test.go
+++ b/internal/output/aws_credentials_file_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/okta/okta-aws-cli/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"

--- a/internal/output/envvar.go
+++ b/internal/output/envvar.go
@@ -19,8 +19,8 @@ package output
 import (
 	"runtime"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
 )
 
 // EnvVar Environment Variable output formatter

--- a/internal/output/noop.go
+++ b/internal/output/noop.go
@@ -17,8 +17,8 @@
 package output
 
 import (
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
 )
 
 // NoopCredentials Don't output credentials

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -19,8 +19,8 @@ package output
 import (
 	"time"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
 )
 
 // Outputter Interface to output AWS credentials in different formats.

--- a/internal/output/process_credentials.go
+++ b/internal/output/process_credentials.go
@@ -19,8 +19,8 @@ package output
 import (
 	"encoding/json"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	"github.com/okta/okta-aws-cli/internal/config"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
 )
 
 // ProcessCredentials AWS CLI Process Credentials output formatter

--- a/internal/output/process_credentials_test.go
+++ b/internal/output/process_credentials_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/okta/okta-aws-cli/internal/aws"
+	"github.com/okta/okta-aws-cli/v2/internal/aws"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/paginator/paginator.go
+++ b/internal/paginator/paginator.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/okta/okta-aws-cli/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
 )
 
 const (

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -30,8 +30,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/utils"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/utils"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
 )
 
 const (

--- a/internal/webssoauth/webssoauth.go
+++ b/internal/webssoauth/webssoauth.go
@@ -47,14 +47,14 @@ import (
 	brwsr "github.com/pkg/browser"
 	"golang.org/x/net/html"
 
-	oaws "github.com/okta/okta-aws-cli/internal/aws"
-	boff "github.com/okta/okta-aws-cli/internal/backoff"
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/exec"
-	"github.com/okta/okta-aws-cli/internal/okta"
-	"github.com/okta/okta-aws-cli/internal/output"
-	"github.com/okta/okta-aws-cli/internal/paginator"
-	"github.com/okta/okta-aws-cli/internal/utils"
+	oaws "github.com/okta/okta-aws-cli/v2/internal/aws"
+	boff "github.com/okta/okta-aws-cli/v2/internal/backoff"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/exec"
+	"github.com/okta/okta-aws-cli/v2/internal/okta"
+	"github.com/okta/okta-aws-cli/v2/internal/output"
+	"github.com/okta/okta-aws-cli/v2/internal/paginator"
+	"github.com/okta/okta-aws-cli/v2/internal/utils"
 )
 
 const (

--- a/internal/webssoauth/webssoauth_test.go
+++ b/internal/webssoauth/webssoauth_test.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/okta/okta-aws-cli/internal/config"
-	"github.com/okta/okta-aws-cli/internal/testutils"
+	"github.com/okta/okta-aws-cli/v2/internal/config"
+	"github.com/okta/okta-aws-cli/v2/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
This fixes the `v2` version download error when `okta-aws-cli` is downloaded by `go get`.