### PR TITLE
fix "RuntimeError: Could not determine home directory" on windows whe…

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -75,6 +75,10 @@ func (e *Exec) Run(cc *oaws.CredentialContainer) error {
 		if strings.HasPrefix(k, "AWS_") {
 			pairs[k] = pair[1]
 		}
+                // fix 'RuntimeError: Could not determine home directory.' on windows when using --exec to run AWS cli v2
+                if strings.HasPrefix(k, "HOME") {
+			pairs[k] = pair[1]
+		}
 	}
 	// add creds env var names to pairs
 	pairs["AWS_ACCESS_KEY_ID"] = cc.AccessKeyID


### PR DESCRIPTION
Fixes:

```
error running process
aws s3 ls
Traceback (most recent call last):
  File "aws.py", line 19, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 384, in exec_module
  File "awscli\clidriver.py", line 78, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 384, in exec_module
  File "awscli\telemetry.py", line 31, in <module>
  File "pathlib\_abc.py", line 758, in home
  File "pathlib\_local.py", line 808, in expanduser
RuntimeError: Could not determine home directory.
[PYI-1964:ERROR] Failed to execute script 'aws' due to unhandled exception!

Error: exit status 1
Usage:
```

on Windows system when `--exec` is used to run a aws cli command (`--exec -- aws s3 ls`)