### PR TITLE
fix: update chocolatey workflow

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -2,7 +2,7 @@ name: Chocolatey Deploy
 
 # This GH action will push a okta-aws-cli build to chocolatey.org when a
 # okta-aws-cli GH release is completed.
-# 
+#
 # inspired by https://github.com/rcmaehl/MSEdgeRedirect thank you rcmaehl 🙏🙏🙏
 
 on:
@@ -18,52 +18,74 @@ jobs:
   chocolatey:
     runs-on: windows-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Unshallow
+
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Get latest release tag
+
+      - name: Get latest release tag
         uses: oprypin/find-latest-tag@v1
         with:
           repository: ${{ github.repository }}
           releases-only: true
         id: latesttag
-      -
-        name: Set Version
+
+      - name: Set Version
         id: version
         run: |
           version=$(echo "${{ steps.latesttag.outputs.tag }}" | grep -oE "[[:digit:]]{1,}\.[[:digit:]]{1,}\.[[:digit:]]{1,}")
           echo "nuget=$version" >> $GITHUB_OUTPUT
           sed -i "s/{VERSION}/${version}/g" "nuspec/chocolatey/okta-aws-cli.nuspec"
-      -
-        name: Set Checksum
+
+      - name: Download and Embed Binary
         run: |
           filename="okta-aws-cli_${{ steps.version.outputs.nuget }}_windows_386.zip"
           url="https://github.com/${{ github.repository }}/releases/download/${{ steps.latesttag.outputs.tag }}/${filename}"
-          sed -i "s#{ZIPURL}#${url}#g" "nuspec/chocolatey/tools/chocolateyinstall.ps1"
-          curl -sSL "${url}" -o "nuspec/chocolatey/${filename}"
-          sha256=$(cat "nuspec/chocolatey/${filename}" | sha256sum -)
-          sed -i "s/{SHA256CHECKSUM}/${sha256:0:64}/g" "nuspec/chocolatey/tools/chocolateyinstall.ps1"
-      -
-        name: Choco Downgrade
+
+          # Retry download with exponential backoff to handle release asset propagation delay
+          download_success=false
+          for i in 1 2 3 4 5; do
+            echo "Download attempt $i..."
+            if curl -sSL --fail "${url}" -o "nuspec/chocolatey/tools/okta-aws-cli.zip"; then
+              download_success=true
+              break
+            fi
+            echo "Download failed, waiting $((i * 30)) seconds before retry..."
+            sleep $((i * 30))
+          done
+
+          if [ "$download_success" != "true" ]; then
+            echo "ERROR: Failed to download release asset after 5 attempts"
+            exit 1
+          fi
+
+          # Verify the downloaded file is a valid zip archive (zip files start with "PK")
+          if [ "$(head -c 2 "nuspec/chocolatey/tools/okta-aws-cli.zip")" != "PK" ]; then
+            echo "ERROR: Downloaded file is not a valid zip archive"
+            exit 1
+          fi
+
+          echo "Successfully downloaded and verified binary"
+          ls -la nuspec/chocolatey/tools/
+
+      - name: Choco Downgrade
         uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install chocolatey --version=1.2.1 --allow-downgrade -y -r --no-progress
-      -
-        name: Pack Release
+
+      - name: Pack Release
         uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: pack nuspec/chocolatey/okta-aws-cli.nuspec --outputdirectory nuspec/chocolatey
-      -
-        name: Choco Upgrade
+
+      - name: Choco Upgrade
         uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: upgrade chocolatey
-      -
-        name: Upload Release
+
+      - name: Upload Release
         uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: push nuspec/chocolatey/okta-aws-cli.${{ steps.version.outputs.nuget }}.nupkg -s https://push.chocolatey.org/ -k ${{ secrets.CHOCO_API_KEY }}
+

--- a/nuspec/chocolatey/tools/chocolateyinstall.ps1
+++ b/nuspec/chocolatey/tools/chocolateyinstall.ps1
@@ -1,30 +1,10 @@
-
 $ErrorActionPreference = 'Stop'
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  unzipLocation = $toolsDir
-  url           = '{ZIPURL}'
-  checksum      = '{SHA256CHECKSUM}'
-  checksumType  = 'sha256'
-}
+# Extract the embedded zip file (no remote download needed)
+$zipPath = Join-Path -Path $toolsDir -ChildPath 'okta-aws-cli.zip'
+Get-ChocolateyUnzip -FileFullPath $zipPath -Destination $toolsDir -PackageName $env:ChocolateyPackageName
 
-Install-ChocolateyZipPackage @packageArgs
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+# Clean up the zip after extraction
+Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Problem
Fixes Chocolatey publishing failures (v2.5.2, v2.5.3) caused by a race condition where the workflow downloaded GitHub's 404 error page instead of the actual binary.

## Solution
Embed the binary directly in the package instead of downloading at install time (same approach as [okta-powershell-cli](https://github.com/okta/okta-powershell-cli)).
Added retry logic with backoff and zip validation to handle asset propagation delays.
